### PR TITLE
Clean up lint issues and jsdoc comments

### DIFF
--- a/src/helpers/choose-port.js
+++ b/src/helpers/choose-port.js
@@ -73,6 +73,5 @@ module.exports = ( port = DEFAULT_PORT ) => choosePort( HOST, parseInt( port, 10
 			return selectedPort;
 		}
 		// If the user declined to run on another port, we assume we cannot proceed.
-		console.error( chalk.red( `\nPort ${ port } busy: Terminating process.` ) );
-		process.exit( 0 );
+		throw new Error( chalk.red( `\nPort ${ port } busy: Terminating process.` ) );
 	} );

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -33,7 +33,7 @@ module.exports = {
 	 * @param {Object[]} plugins           Array of plugin instance objects.
 	 * @param {Function} PluginConstructor Constructor function for which to check
 	 *                                     for existing plugin instances.
-	 * @returns {Object} The matched plugin instance object, or null.
+	 * @returns {(Object|null)} The matched plugin instance object, or null.
 	 */
 	findExistingInstance: ( plugins, PluginConstructor ) => {
 		if ( ! Array.isArray( plugins ) ) {
@@ -46,6 +46,9 @@ module.exports = {
 	/**
 	 * Create a new BundleAnalyzerPlugin instance. The analyzer is enabled by default
 	 * only if `--analyze` is passed on the command line.
+	 *
+	 * @param {Object} [options] Plugin configuration options.
+	 * @returns {BundleAnalyzerPlugin} A configured BundleAnalyzerPlugin instance.
 	 */
 	bundleAnalyzer: ( options = {} ) => new BundleAnalyzerPlugin( {
 		analyzerMode: process.argv.indexOf( '--analyze' ) >= 0 ? 'static' : 'disabled',
@@ -62,7 +65,7 @@ module.exports = {
 	 * @param {String}   [options.root] Absolute path to your webpack root folder;
 	 *                                  defaults to process.cwd(). The values in
 	 *                                  `paths` are relative to this directory.
-	 * @returns {CleanPlugin}
+	 * @returns {CleanPlugin} A configured CleanPlugin instance.
 	 */
 	clean: ( paths, options = {} ) => new CleanPlugin( paths, {
 		root: process.cwd(),
@@ -81,6 +84,7 @@ module.exports = {
 	 *
 	 * @param {CopyPattern[]} patterns  Array of pattern objects ( `{ from, to[, test] }` ).
 	 * @param {Object}        [options] Optional plugin options object.
+	 * @returns {CopyPlugin} A configured CopyPlugin instance.
 	 */
 	copy: ( patterns, options ) => new CopyPlugin( patterns, options ),
 
@@ -88,8 +92,9 @@ module.exports = {
 	 * Create a new FixStyleOnlyEntriesPlugin instance to remove unnecessary JS
 	 * files generated for style-only bundle entries.
 	 *
-	 * @param {Object} [options] Plugin options object
+	 * @param {Object} [options]         Plugin options object
 	 * @param {RegExp} [options.exclude] Regular expression to filter what gets cleaned.
+	 * @returns {FixStyleOnlyEntriesPlugin} A configured FixStyleOnlyEntriesPlugin instance.
 	 */
 	fixStyleOnlyEntries: ( options ) => new FixStyleOnlyEntriesPlugin( options ),
 
@@ -97,7 +102,7 @@ module.exports = {
 	 * Create a webpack.HotModuleReplacementPlugin instance.
 	 *
 	 * @param {Object} [opts] Optional plugin options object.
-	 * @returns {HotModuleReplacementPlugin}
+	 * @returns {HotModuleReplacementPlugin} A configured HMR Plugin instance.
 	 */
 	hotModuleReplacement: ( opts = {} ) => new HotModuleReplacementPlugin( opts ),
 
@@ -122,7 +127,6 @@ module.exports = {
 	 *
 	 * @param {Object} [opts]          Optional plugin configuration options.
 	 * @param {Object} [opts.filename] The filename to use for the output CSS.
-	 *
 	 * @returns {MiniCssExtractPlugin} A configured MiniCssExtractPlugin instance.
 	 */
 	miniCssExtract: ( opts = {} ) => new MiniCssExtractPlugin( {
@@ -133,8 +137,7 @@ module.exports = {
 	/**
 	 * Create a new OptimizeCssAssetsPlugin instance.
 	 *
-	 * @param {Object} [opts]          Optional plugin configuration options.
-	 *
+	 * @param {Object} [opts]  Optional plugin configuration options.
 	 * @returns {OptimizeCssAssetsPlugin} A configured OptimizeCssAssetsPlugin instance.
 	 */
 	optimizeCssAssets: ( opts = {} ) => new OptimizeCssAssetsPlugin( opts ),
@@ -144,8 +147,9 @@ module.exports = {
 	 * borrowed from create-react-app's configuration.
 	 *
 	 * @param {Object} [opts]               Plugin configuration option overrides
-	 *                                         to merge into the defaults.
+	 *                                      to merge into the defaults.
 	 * @param {Object} [opts.terserOptions] Terser compressor options object.
+	 * @returns {TerserPlugin} A configured TerserPlugin instance.
 	 */
 	terser: ( opts = {} ) => new TerserPlugin( deepMerge( {
 		terserOptions: {

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -47,7 +47,7 @@ module.exports = {
 	 * Create a new BundleAnalyzerPlugin instance. The analyzer is enabled by default
 	 * only if `--analyze` is passed on the command line.
 	 *
-	 * @param {Object} [options] Plugin configuration options.
+	 * @param {Object} [options] Optional plugin options object.
 	 * @returns {BundleAnalyzerPlugin} A configured BundleAnalyzerPlugin instance.
 	 */
 	bundleAnalyzer: ( options = {} ) => new BundleAnalyzerPlugin( {
@@ -61,7 +61,7 @@ module.exports = {
 	 * Create a CleanPlugin instance.
 	 *
 	 * @param {String[]} paths          Array of (relative) string paths to clean.
-	 * @param {Object}   [options]      Plugin configuration options.
+	 * @param {Object}   [options]      Optional plugin options object.
 	 * @param {String}   [options.root] Absolute path to your webpack root folder;
 	 *                                  defaults to process.cwd(). The values in
 	 *                                  `paths` are relative to this directory.
@@ -92,7 +92,7 @@ module.exports = {
 	 * Create a new FixStyleOnlyEntriesPlugin instance to remove unnecessary JS
 	 * files generated for style-only bundle entries.
 	 *
-	 * @param {Object} [options]         Plugin options object
+	 * @param {Object} [options]         Optional plugin options object.
 	 * @param {RegExp} [options.exclude] Regular expression to filter what gets cleaned.
 	 * @returns {FixStyleOnlyEntriesPlugin} A configured FixStyleOnlyEntriesPlugin instance.
 	 */
@@ -101,10 +101,10 @@ module.exports = {
 	/**
 	 * Create a webpack.HotModuleReplacementPlugin instance.
 	 *
-	 * @param {Object} [opts] Optional plugin options object.
+	 * @param {Object} [options] Optional plugin options object.
 	 * @returns {HotModuleReplacementPlugin} A configured HMR Plugin instance.
 	 */
-	hotModuleReplacement: ( opts = {} ) => new HotModuleReplacementPlugin( opts ),
+	hotModuleReplacement: ( options = {} ) => new HotModuleReplacementPlugin( options ),
 
 	/**
 	 * Create a new ManifestPlugin instance to output an asset-manifest.json
@@ -112,46 +112,46 @@ module.exports = {
 	 * assets from the development server. A publicPath matching the URL
 	 * in the configuration's output.publicPath is required.
 	 *
-	 * @param {Object} opts            Plugin options overrides.
-	 * @param {String} opts.publicPath The base URI to prepend to build asset URIs.
+	 * @param {Object} options            Plugin options overrides.
+	 * @param {String} options.publicPath The base URI to prepend to build asset URIs.
 	 * @returns {ManifestPlugin} A configured ManifestPlugin instance.
 	 */
-	manifest: ( opts = {} ) => new ManifestPlugin( {
+	manifest: ( options = {} ) => new ManifestPlugin( {
 		fileName: 'asset-manifest.json',
 		writeToFileEmit: true,
-		...opts,
+		...options,
 	} ),
 
 	/**
 	 * Create a new MiniCssExtractPlugin instance.
 	 *
-	 * @param {Object} [opts]          Optional plugin configuration options.
-	 * @param {Object} [opts.filename] The filename to use for the output CSS.
+	 * @param {Object} [options]          Optional plugin configuration options.
+	 * @param {Object} [options.filename] The filename to use for the output CSS.
 	 * @returns {MiniCssExtractPlugin} A configured MiniCssExtractPlugin instance.
 	 */
-	miniCssExtract: ( opts = {} ) => new MiniCssExtractPlugin( {
+	miniCssExtract: ( options = {} ) => new MiniCssExtractPlugin( {
 		filename: '[name].css',
-		...opts,
+		...options,
 	} ),
 
 	/**
 	 * Create a new OptimizeCssAssetsPlugin instance.
 	 *
-	 * @param {Object} [opts]  Optional plugin configuration options.
+	 * @param {Object} [options] Optional plugin configuration options.
 	 * @returns {OptimizeCssAssetsPlugin} A configured OptimizeCssAssetsPlugin instance.
 	 */
-	optimizeCssAssets: ( opts = {} ) => new OptimizeCssAssetsPlugin( opts ),
+	optimizeCssAssets: ( options = {} ) => new OptimizeCssAssetsPlugin( options ),
 
 	/**
 	 * Create a new TerserPlugin instance, defaulting to a set of options
 	 * borrowed from create-react-app's configuration.
 	 *
-	 * @param {Object} [opts]               Plugin configuration option overrides
-	 *                                      to merge into the defaults.
-	 * @param {Object} [opts.terserOptions] Terser compressor options object.
+	 * @param {Object} [options]               Plugin configuration option overrides
+	 *                                         to merge into the defaults.
+	 * @param {Object} [options.terserOptions] Terser compressor options object.
 	 * @returns {TerserPlugin} A configured TerserPlugin instance.
 	 */
-	terser: ( opts = {} ) => new TerserPlugin( deepMerge( {
+	terser: ( options = {} ) => new TerserPlugin( deepMerge( {
 		terserOptions: {
 			parse: {
 				// we want terser to parse ecma 8 code. However, we don't want it
@@ -193,5 +193,5 @@ module.exports = {
 		cache: true,
 		// Output sourcemaps.
 		sourceMap: true,
-	}, opts ) ),
+	}, options ) ),
 };

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -5,7 +5,7 @@ const CopyPlugin = require( 'copy-webpack-plugin' );
 const ManifestPlugin = require( 'webpack-manifest-plugin' );
 const MiniCssExtractPlugin = require( 'mini-css-extract-plugin' );
 const TerserPlugin = require( 'terser-webpack-plugin' );
-const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
+const OptimizeCssAssetsPlugin = require( 'optimize-css-assets-webpack-plugin' );
 
 const deepMerge = require( './helpers/deep-merge' );
 const FixStyleOnlyEntriesPlugin = require( './plugins/webpack-fix-style-only-entries' );

--- a/src/presets.js
+++ b/src/presets.js
@@ -19,10 +19,10 @@ const { ManifestPlugin, MiniCssExtractPlugin } = plugins.constructors;
  * - an `.output.publicPath` string (unless a devServer.port is specified,
  *   in which case publicPath defaults to `http://localhost:${ port }`)
  *
- * @param {Object} opts Configuration options to deeply merge into the defaults.
+ * @param {Object} options Configuration options to deeply merge into the defaults.
  * @returns {Object} A merged Webpack configuration object.
  */
-const development = ( opts = {} ) => {
+const development = ( options = {} ) => {
 	/**
 	 * Default development environment-oriented Webpack options. This object is
 	 * defined at the time of function execution so that any changes to the
@@ -102,24 +102,24 @@ const development = ( opts = {} ) => {
 	};
 
 	// Make some general assumptions about the publicPath URI based on the
-	// configuration values provided in opts.
-	const port = findInObject( opts, 'devServer.port' );
-	let publicPath = findInObject( opts, 'output.publicPath' );
+	// configuration values provided in options.
+	const port = findInObject( options, 'devServer.port' );
+	let publicPath = findInObject( options, 'output.publicPath' );
 	if ( ! publicPath && port ) {
 		publicPath = `${
-			findInObject( opts, 'devServer.https' ) ? 'https' : 'http'
+			findInObject( options, 'devServer.https' ) ? 'https' : 'http'
 		}://localhost:${ port }/`;
 	}
 
 	// If we had enough value to guess a publicPath, set that path as a default
 	// wherever appropriate and inject a ManifestPlugin instance to expose that
 	// public path to consuming applications. Any inferred values will still be
-	// overridden with their relevant values from `opts`, when provided.
+	// overridden with their relevant values from `options`, when provided.
 	if ( publicPath ) {
 		devDefaults.output.publicPath = publicPath;
 
-		// Check for an existing ManifestPlugin instance in opts.plugins.
-		const hasManifestPlugin = plugins.findExistingInstance( opts.plugins, ManifestPlugin );
+		// Check for an existing ManifestPlugin instance in options.plugins.
+		const hasManifestPlugin = plugins.findExistingInstance( options.plugins, ManifestPlugin );
 		// Add a manifest with the inferred publicPath if none was present.
 		if ( ! hasManifestPlugin ) {
 			devDefaults.plugins.push( plugins.manifest( {
@@ -128,7 +128,7 @@ const development = ( opts = {} ) => {
 		}
 	}
 
-	return deepMerge( devDefaults, opts );
+	return deepMerge( devDefaults, options );
 };
 
 /**
@@ -142,10 +142,10 @@ const development = ( opts = {} ) => {
  * - an `.entry` object,
  * - an `.output.path` string
  *
- * @param {Object} opts Configuration options to deeply merge into the defaults.
+ * @param {Object} options Configuration options to deeply merge into the defaults.
  * @returns {Object} A merged Webpack configuration object.
  */
-const production = ( opts = {} ) => {
+const production = ( options = {} ) => {
 	/**
 	 * Default development environment-oriented Webpack options. This object is
 	 * defined at the time of function execution so that any changes to the
@@ -213,13 +213,13 @@ const production = ( opts = {} ) => {
 		plugins: [],
 	};
 
-	// Add a MiniCssExtractPlugin instance if none is already present in opts.
-	const hasCssPlugin = plugins.findExistingInstance( opts.plugins, MiniCssExtractPlugin );
+	// Add a MiniCssExtractPlugin instance if none is already present in options.
+	const hasCssPlugin = plugins.findExistingInstance( options.plugins, MiniCssExtractPlugin );
 	if ( ! hasCssPlugin ) {
 		prodDefaults.plugins.push( plugins.miniCssExtract() );
 	}
 
-	return deepMerge( prodDefaults, opts );
+	return deepMerge( prodDefaults, options );
 };
 
 /**

--- a/src/presets.test.js
+++ b/src/presets.test.js
@@ -53,6 +53,6 @@ describe( 'presets', () => {
 		} );
 
 		// TODO: Add test cases for all logic branches in production().
-		// it( 'injects a MiniCssExtractPlugin if none is present in opts' );
+		// it( 'injects a MiniCssExtractPlugin if none is present in options' );
 	} );
 } );


### PR DESCRIPTION
- Use `options` consistently when naming arguments, instead of `opts`.
- Fix ESLint issues
- Standardize alignment of JSDoc param syntax (all params aligned) and returns lines (not aligned with params)