### PR TITLE
Allow for caching the Babel preset

### DIFF
--- a/babel-preset.js
+++ b/babel-preset.js
@@ -1,5 +1,5 @@
 module.exports = ( api ) => {
-	api.cache( true );
+	api.cache.forever();
 
 	return {
 		presets: [ '@wordpress/default' ],

--- a/babel-preset.js
+++ b/babel-preset.js
@@ -1,8 +1,12 @@
-module.exports = {
-	presets: [ '@wordpress/default' ],
-	plugins: [
-		[ 'transform-react-jsx', {
-			pragma: 'wp.element.createElement',
-		} ],
-	],
+module.exports = ( api ) => {
+	api.cache( true );
+
+	return {
+		presets: [ '@wordpress/default' ],
+		plugins: [
+			[ 'transform-react-jsx', {
+				pragma: 'wp.element.createElement',
+			} ],
+		],
+	};
 };


### PR DESCRIPTION
JavaScript-based Babel preset files will be executed over and over again, unless they dictate if and how they can be cached (see [`api.cache`](https://babeljs.io/docs/en/config-files#apicache)).

I was wondering if it makes sense to cache the preset (_forever_) as it doesn't include any dynamic things at all anyway...?