### PR TITLE
Fix filePath test for Windows

### DIFF
--- a/src/helpers/file-path.js
+++ b/src/helpers/file-path.js
@@ -1,3 +1,4 @@
+const process = require( 'process' );
 const { join } = require( 'path' );
 
 /**

--- a/src/helpers/file-path.test.js
+++ b/src/helpers/file-path.test.js
@@ -1,9 +1,29 @@
 const filePath = require( './file-path' );
 
+jest.mock( 'process', () => ( { cwd: () => 'cwd' } ) );
+
+expect.extend( {
+	toMatchFilePath( received, expected ) {
+		const pass = ( new RegExp( received.replace( /(\\|\/)/g, '(\\\\|\/)' ) ) ).test( expected );
+		if ( pass ) {
+			return {
+				message: () => `expected ${ received } not to match file path ${ expected }`,
+				pass: true,
+			};
+		}
+
+		return {
+			message: () => `expected ${ received } to match file path ${ expected }`,
+			pass: false,
+		};
+	},
+} );
+
 describe( 'helpers/file-path', () => {
 	it( 'properly generates a file system theme file path', () => {
-		expect( filePath() ).toBe( process.cwd() );
-		expect( filePath( 'themes/theme-name' ) ).toBe( `${ process.cwd() }/themes/theme-name` );
-		expect( filePath( 'themes', 'theme-name', 'style.css' ) ).toBe( `${ process.cwd() }/themes/theme-name/style.css` );
+		expect( filePath() ).toMatchFilePath( 'cwd' );
+		expect( filePath( 'themes/theme-name' ) ).toMatchFilePath( 'cwd/themes/theme-name' );
+		expect( filePath( 'themes\\theme-name' ) ).toMatchFilePath( 'cwd/themes/theme-name' );
+		expect( filePath( 'themes', 'theme-name', 'style.css' ) ).toMatchFilePath( 'cwd/themes/theme-name/style.css' );
 	} );
 } );

--- a/src/helpers/file-path.test.js
+++ b/src/helpers/file-path.test.js
@@ -3,8 +3,8 @@ const filePath = require( './file-path' );
 jest.mock( 'process', () => ( { cwd: () => 'cwd' } ) );
 
 expect.extend( {
-	toMatchFilePath( received, expected ) {
-		const pass = ( new RegExp( received.replace( /(\\|\/)/g, '(\\\\|\/)' ) ) ).test( expected );
+	toMatchFilePath: ( received, expected ) => {
+		const pass = ( new RegExp( received.replace( /(\\|\/)/g, '(\\\\|/)' ) ) ).test( expected );
 		if ( pass ) {
 			return {
 				message: () => `expected ${ received } not to match file path ${ expected }`,


### PR DESCRIPTION
The `filePath` test was only working with linux-style paths (or rather: directory separators).

For Windows, you would get something like this:

![jest](https://user-images.githubusercontent.com/6049306/62851470-700e5c00-bce6-11e9-800b-60f83fe348e0.png)

This PR includes the following:

* add custom Jest matcher that understands both linux and Windows paths (via a regular expression);
* add Windows path test case;
* manually import `process` in the `file-path.js` file so it can be mocked in the test.