### PR TITLE
Use content hash in chunk filename

### DIFF
--- a/src/presets.js
+++ b/src/presets.js
@@ -49,7 +49,7 @@ const development = ( options = {} ) => {
 			// Provide a default output name.
 			filename: '[name].js',
 			// Provide chunk filename. Requires content hash for cache busting.
-			chunkFilename: '[name].[contenthash].chunk.js'
+			chunkFilename: '[name].[contenthash].chunk.js',
 		},
 
 		module: {
@@ -175,7 +175,7 @@ const production = ( options = {} ) => {
 			// Provide a default output name.
 			filename: '[name].js',
 			// Provide chunk filename. Requires content hash for cache busting.
-			chunkFilename: '[name].[contenthash].chunk.js'
+			chunkFilename: '[name].[contenthash].chunk.js',
 		},
 
 		module: {

--- a/src/presets.js
+++ b/src/presets.js
@@ -48,6 +48,8 @@ const development = ( options = {} ) => {
 			pathinfo: true,
 			// Provide a default output name.
 			filename: '[name].js',
+			// Provide chunk filename. Requires content hash for cache busting.
+			chunkFilename: '[name].[contenthash].chunk.js'
 		},
 
 		module: {
@@ -172,6 +174,8 @@ const production = ( options = {} ) => {
 			pathinfo: false,
 			// Provide a default output name.
 			filename: '[name].js',
+			// Provide chunk filename. Requires content hash for cache busting.
+			chunkFilename: '[name].[contenthash].chunk.js'
 		},
 
 		module: {

--- a/src/presets.test.js
+++ b/src/presets.test.js
@@ -20,6 +20,7 @@ describe( 'presets', () => {
 			expect( config.output ).toEqual( {
 				pathinfo: true,
 				filename: '[name].js',
+				chunkFilename: '[name].[contenthash].chunk.js',
 				path: 'build/',
 			} );
 		} );
@@ -48,6 +49,7 @@ describe( 'presets', () => {
 			expect( config.output ).toEqual( {
 				pathinfo: false,
 				filename: '[name].js',
+				chunkFilename: '[name].[contenthash].chunk.js',
 				path: 'build/',
 			} );
 		} );


### PR DESCRIPTION
I have been looking into using `React.lazy`, and async imports in order to break up large bundles. However I ran into an issue with the browser caching chunk files. 

The default `filename` setting is `[name].js`, with no hash. When used in conjunction with [HM Asset Loader](https://github.com/humanmade/asset-loader) this is fine - it adds the filemtime as a query param using the WordPress asset versioning arg.

But this isn't fine for chunk files. By default, `chunkFilename` is inferred from the `filename`, and thus when using webpack helpers, you will see files like `0.js` used for chunks. If the contents of the chunk changes, the browser may serve a cached chunk and things will fall over. 

If we specify a hash in the `chunkFilename` - it all works great!