### PR TITLE
Fix issue where entry is improperly merged with default

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,11 @@
     "lint": "eslint .",
     "test": "jest"
   },
+  "jest": {
+    "setupFilesAfterEnv": [
+      "<rootDir>/src/setupTests.js"
+    ]
+  },
   "devDependencies": {
     "eslint": "^5.13.0",
     "jest": "^24.8.0",

--- a/src/helpers/file-path.test.js
+++ b/src/helpers/file-path.test.js
@@ -1,6 +1,6 @@
 const filePath = require( './file-path' );
 
-// Depends on custom matchers defined in __tests__/setup.js.
+jest.mock( 'process', () => ( { cwd: () => 'cwd' } ) );
 
 describe( 'helpers/file-path', () => {
 	it( 'properly generates a file system theme file path', () => {

--- a/src/helpers/file-path.test.js
+++ b/src/helpers/file-path.test.js
@@ -1,23 +1,6 @@
 const filePath = require( './file-path' );
 
-jest.mock( 'process', () => ( { cwd: () => 'cwd' } ) );
-
-expect.extend( {
-	toMatchFilePath: ( received, expected ) => {
-		const pass = ( new RegExp( received.replace( /(\\|\/)/g, '(\\\\|/)' ) ) ).test( expected );
-		if ( pass ) {
-			return {
-				message: () => `expected ${ received } not to match file path ${ expected }`,
-				pass: true,
-			};
-		}
-
-		return {
-			message: () => `expected ${ received } to match file path ${ expected }`,
-			pass: false,
-		};
-	},
-} );
+// Depends on custom matchers defined in __tests__/setup.js.
 
 describe( 'helpers/file-path', () => {
 	it( 'properly generates a file system theme file path', () => {

--- a/src/presets.js
+++ b/src/presets.js
@@ -35,10 +35,7 @@ const development = ( options = {} ) => {
 
 		context: process.cwd(),
 
-		// Provide a default entry point.
-		entry: {
-			index: filePath( 'src/index.js' ),
-		},
+		// Inject a default entry point later on if none was specified.
 
 		// `publicPath` should be specified by the consumer.
 		output: {
@@ -108,6 +105,13 @@ const development = ( options = {} ) => {
 		],
 	};
 
+	// If no entry was provided, inject a default entry value.
+	if ( ! options.entry ) {
+		devDefaults.entry = {
+			index: filePath( 'src/index.js' ),
+		};
+	}
+
 	// Make some general assumptions about the publicPath URI based on the
 	// configuration values provided in options.
 	const port = findInObject( options, 'devServer.port' );
@@ -161,10 +165,7 @@ const production = ( options = {} ) => {
 
 		context: process.cwd(),
 
-		// Provide a default entry point.
-		entry: {
-			index: filePath( 'src/index.js' ),
-		},
+		// Inject a default entry point later on if none was specified.
 
 		output: {
 			// Provide a default output path.
@@ -221,6 +222,13 @@ const production = ( options = {} ) => {
 
 		plugins: [],
 	};
+
+	// If no entry was provided, inject a default entry value.
+	if ( ! options.entry ) {
+		prodDefaults.entry = {
+			index: filePath( 'src/index.js' ),
+		};
+	}
 
 	// Add a MiniCssExtractPlugin instance if none is already present in options.
 	const hasCssPlugin = plugins.findExistingInstance( options.plugins, MiniCssExtractPlugin );

--- a/src/presets.test.js
+++ b/src/presets.test.js
@@ -3,6 +3,8 @@ const {
 	production,
 } = require( './presets' );
 
+jest.mock( 'process', () => ( { cwd: () => 'cwd' } ) );
+
 describe( 'presets', () => {
 	describe( 'development()', () => {
 		it( 'is a function', () => {

--- a/src/presets.test.js
+++ b/src/presets.test.js
@@ -24,6 +24,23 @@ describe( 'presets', () => {
 			} );
 		} );
 
+		it( 'supplies a default entry if none is provided', () => {
+			const config = development();
+			expect( config.entry ).toHaveProperty( 'index' );
+			expect( config.entry.index ).toMatchFilePath( 'cwd/src/index.js' );
+		} );
+
+		it( 'uses a provided entry object without alteration', () => {
+			const config = development( {
+				entry: {
+					main: 'some-file.js',
+				},
+			} );
+			expect( config.entry ).toEqual( {
+				main: 'some-file.js',
+			} );
+		} );
+
 		// TODO: Add test cases for all logic branches in development().
 		// it( 'assumes a default output.publicPath if a port is specified' );
 		// it( 'accounts for the value of devServer.https when inferring publicPath URI' );
@@ -49,6 +66,23 @@ describe( 'presets', () => {
 				pathinfo: false,
 				filename: '[name].js',
 				path: 'build/',
+			} );
+		} );
+
+		it( 'supplies a default entry if none is provided', () => {
+			const config = production();
+			expect( config.entry ).toHaveProperty( 'index' );
+			expect( config.entry.index ).toMatchFilePath( 'cwd/src/index.js' );
+		} );
+
+		it( 'uses a provided entry object without alteration', () => {
+			const config = production( {
+				entry: {
+					main: 'some-file.js',
+				},
+			} );
+			expect( config.entry ).toEqual( {
+				main: 'some-file.js',
 			} );
 		} );
 

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,4 +1,6 @@
-jest.mock( 'process', () => ( { cwd: () => 'cwd' } ) );
+/**
+ * Define custom Jest matchers.
+ */
 
 expect.extend( {
 	toMatchFilePath: ( received, expected ) => {

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,18 @@
+jest.mock( 'process', () => ( { cwd: () => 'cwd' } ) );
+
+expect.extend( {
+	toMatchFilePath: ( received, expected ) => {
+		const pass = ( new RegExp( received.replace( /(\\|\/)/g, '(\\\\|/)' ) ) ).test( expected );
+		if ( pass ) {
+			return {
+				message: () => `expected ${ received } not to match file path ${ expected }`,
+				pass: true,
+			};
+		}
+
+		return {
+			message: () => `expected ${ received } to match file path ${ expected }`,
+			pass: false,
+		};
+	},
+} );


### PR DESCRIPTION
Fixes #30

We cannot naively merge the entry object, or we get unexpected behavior where the build fails because the index property does not resolve. This fixes the logic to only apply our default entry configuration object if none was present in the user-provided configuration argument.