### PR TITLE
Set emitWarning: true in development for HMR

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,10 @@ nav_order: 10
 
 # Changelog
 
+## v0.6.1
+
+- Set `emitWarning: true` in development preset's `eslint-loader` configuration so that lint errors do not block hot updates.
+
 ## v0.6.0
 
 - Add TypeScript support. If the `typescript` package is detected, the presets will use `ts-loader` to interpret `.ts` and `.tsx` files. [#38](https://github.com/humanmade/webpack-helpers/pull/38)
@@ -14,7 +18,7 @@ nav_order: 10
 ## v0.5.2
 
 - Fix bug where bundle keys in the `entry` configuration object were not respected. [#30](https://github.com/humanmade/webpack-helpers/issues/30)
-  
+
 ## v0.5.1
 
 - Provide default values for `entry` and `output.path` configuration options. [#28](https://github.com/humanmade/webpack-helpers/pull/28)

--- a/src/presets.js
+++ b/src/presets.js
@@ -185,7 +185,16 @@ const production = ( options = {} ) => {
 			strictExportPresence: true,
 			rules: [
 				// Run all JS files through ESLint, if installed.
-				...( isInstalled( 'eslint' ) ? [ loaders.eslint( { emitWarning: true } ) ] : [] ),
+				...( isInstalled( 'eslint' ) ?
+					[
+						loaders.eslint( {
+							options: {
+								emitWarning: true,
+							},
+						} ),
+					] :
+					[]
+				),
 				{
 					// "oneOf" will traverse all following loaders until one will
 					// match the requirements. If no loader matches, it will fall

--- a/src/presets.js
+++ b/src/presets.js
@@ -16,13 +16,13 @@ const { ManifestPlugin, MiniCssExtractPlugin } = plugins.constructors;
  *         ...ifInstalled( 'eslint', loaders.eslint() ),
  *     ],
  *
- * @param {String} package The string name of the dependency for which to test.
- * @param {Object} loader  A configuration object returned from a loader factory.
+ * @param {String} packageName The string name of the dependency for which to test.
+ * @param {Object} loader      A configuration object returned from a loader factory.
  *
  * @returns {Array} An array containing one loader, or an empty array.
  */
-const ifInstalled = ( package, loader ) => {
-	if ( ! isInstalled( package ) ) {
+const ifInstalled = ( packageName, loader ) => {
+	if ( ! isInstalled( packageName ) ) {
 		return [];
 	}
 	return [ loader ];

--- a/src/presets.js
+++ b/src/presets.js
@@ -8,6 +8,27 @@ const plugins = require( './plugins' );
 const { ManifestPlugin, MiniCssExtractPlugin } = plugins.constructors;
 
 /**
+ * Helper to detect whether a given package is installed, and return a spreadable
+ * array containing an appropriate loader if so.
+ *
+ * @example
+ *     rules: [
+ *         ...ifInstalled( 'eslint', loaders.eslint() ),
+ *     ],
+ *
+ * @param {String} package The string name of the dependency for which to test.
+ * @param {Object} loader  A configuration object returned from a loader factory.
+ *
+ * @returns {Array} An array containing one loader, or an empty array.
+ */
+const ifInstalled = ( package, loader ) => {
+	if ( ! isInstalled( package ) ) {
+		return [];
+	}
+	return [ loader ];
+};
+
+/**
  * Promote a partial Webpack config into a full development-oriented configuration.
  *
  * This function accepts an incomplete Webpack configuration object and deeply
@@ -53,14 +74,18 @@ const development = ( options = {} ) => {
 			strictExportPresence: true,
 			rules: [
 				// Run all JS files through ESLint, if installed.
-				...( isInstalled( 'eslint' ) ? [ loaders.eslint() ] : [] ),
+				...ifInstalled( 'eslint', loaders.eslint( {
+					options: {
+						emitWarning: true,
+					},
+				} ) ),
 				{
 					// "oneOf" will traverse all following loaders until one will
 					// match the requirements. If no loader matches, it will fall
 					// back to the "file" loader at the end of the loader list.
 					oneOf: [
 						// Enable processing TypeScript, if installed.
-						...( isInstalled( 'typescript' ) ? [ loaders.ts() ] : [] ),
+						...ifInstalled( 'typescript', loaders.ts() ),
 						// Process JS with Babel.
 						loaders.js(),
 						// Convert small files to data URIs.
@@ -185,23 +210,14 @@ const production = ( options = {} ) => {
 			strictExportPresence: true,
 			rules: [
 				// Run all JS files through ESLint, if installed.
-				...( isInstalled( 'eslint' ) ?
-					[
-						loaders.eslint( {
-							options: {
-								emitWarning: true,
-							},
-						} ),
-					] :
-					[]
-				),
+				...ifInstalled( 'eslint', loaders.eslint() ),
 				{
 					// "oneOf" will traverse all following loaders until one will
 					// match the requirements. If no loader matches, it will fall
 					// back to the "file" loader at the end of the loader list.
 					oneOf: [
 						// Enable processing TypeScript, if installed.
-						...( isInstalled( 'typescript' ) ? [ loaders.ts() ] : [] ),
+						...ifInstalled( 'typescript', loaders.ts() ),
 						// Process JS with Babel.
 						loaders.js(),
 						// Convert small files to data URIs.

--- a/src/presets.js
+++ b/src/presets.js
@@ -185,7 +185,7 @@ const production = ( options = {} ) => {
 			strictExportPresence: true,
 			rules: [
 				// Run all JS files through ESLint, if installed.
-				...( isInstalled( 'eslint' ) ? [ loaders.eslint() ] : [] ),
+				...( isInstalled( 'eslint' ) ? [ loaders.eslint( { emitWarning: true } ) ] : [] ),
 				{
 					// "oneOf" will traverse all following loaders until one will
 					// match the requirements. If no loader matches, it will fall


### PR DESCRIPTION
@rmccue caught that hot updates were failing on eslint errors, which is happening because the `emitWarning` option was not set in development. From [the `eslint-loader` documentation](https://www.npmjs.com/package/eslint-loader#emitwarning):

> [`eslint-loader`] Will always return warnings, if [`emitWarning`] option is set to true. **If you're using hot module replacement, you may wish to enable this in development, or else updates will be skipped when there's an eslint error.**