### PR TITLE
Disable Terser extractComments setting

### DIFF
--- a/src/plugins.js
+++ b/src/plugins.js
@@ -186,5 +186,6 @@ module.exports = {
 				ascii_only: true,
 			},
 		},
+		extractComments: false,
 	}, options ) ),
 };


### PR DESCRIPTION
As of 0.7.0, bundlename.LICENCE.txt files are generated if a specific set of comments are detected in the input bundles. As these files do not categorically represent the entire bundle, and were not generated in prior versions of the production factory, we should disable comment extraction for now and revisit whether we want to step into this feature mindfully in the future.