### PR TITLE
Switch from autoprefixer to postcss-preset-env

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,7 @@ nav_order: 10
 ## v0.8.0
 
 - **Breaking**: End support for Node v8. Node v10 or later is now required.
+- Add [postcss-preset-env](https://github.com/csstools/postcss-preset-env) to postcss webpack configuration and configure it to transform Stage 3 CSS features [#91](https://github.com/humanmade/webpack-helpers/pull/91)
 
 ## v0.7.1
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "eslint": "^7.3.1",
     "jest": "^26.1.0",
     "node-sass": "^4.13.1",
-    "postcss-preset-env": "^6.7.0",
     "typescript": "^3.9.5",
     "webpack": "^4.35.0",
     "webpack-dev-server": "^3.7.2"
@@ -55,6 +54,7 @@
     "optimize-css-assets-webpack-plugin": "^5.0.1",
     "postcss-flexbugs-fixes": "^4.1.0",
     "postcss-loader": "^3.0.0",
+    "postcss-preset-env": "^6.7.0",
     "sass-loader": "^8.0.2",
     "signal-exit": "^3.0.2",
     "style-loader": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "eslint": "^7.3.1",
     "jest": "^26.1.0",
     "node-sass": "^4.13.1",
+    "postcss-preset-env": "^6.7.0",
     "typescript": "^3.9.5",
     "webpack": "^4.35.0",
     "webpack-dev-server": "^3.7.2"
@@ -38,7 +39,6 @@
     "@babel/core": "^7.10.3",
     "@babel/plugin-proposal-class-properties": "^7.10.1",
     "@wordpress/babel-preset-default": "^4.16.0",
-    "autoprefixer": "^9.8.4",
     "babel-loader": "^8.0.6",
     "babel-plugin-transform-react-jsx": "^6.24.1",
     "block-editor-hmr": "^0.6.0",

--- a/src/loaders.js
+++ b/src/loaders.js
@@ -1,8 +1,8 @@
 /**
  * Export generator functions for common Webpack loader configurations.
  */
-const autoprefixer = require( 'autoprefixer' );
 const postcssFlexbugsFixes = require( 'postcss-flexbugs-fixes' );
+const postcssPresetEnv = require( 'postcss-preset-env' );
 
 const deepMerge = require( './helpers/deep-merge' );
 
@@ -81,8 +81,11 @@ loaders.postcss.defaults = {
 		ident: 'postcss',
 		plugins: () => [
 			postcssFlexbugsFixes,
-			autoprefixer( {
-				flexbox: 'no-2009',
+			postcssPresetEnv( {
+				autoprefixer: {
+					flexbox: 'no-2009',
+				},
+				stage: 3,
 			} ),
 		],
 	},


### PR DESCRIPTION
preset-env wraps autoprefixer and enables lower-config usage of new CSS features when a polyfill exists using conventional CSS (This is what create-react-app has migrated to under the hood)