### PR TITLE
Update CopyPlugin factory function signature to match updated dependency

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,7 @@ nav_order: 10
 
 - **Breaking**: End support for Node v8. Node v10 or later is now required.
 - **Breaking**: Update `clean-webpack-plugin` factory to reflect API changes in the latest bundled version. `plugins.clean()` can now be added to a webpack configuration's `plugins` array with no additional arguments. [#31](https://github.com/humanmade/webpack-helpers/issues/31)
+- **Breaking**: Update `copy-webpack-plugin` factory to reflect API changes in the latest bundled version. `plugins.copy()` now takes a sole object argument specifying a `patterns: []` array key, where before patterns were passed as a first argument. [#96](https://github.com/humanmade/webpack-helpers/pull/96)
 - Add [postcss-preset-env](https://github.com/csstools/postcss-preset-env) to postcss webpack configuration and configure it to transform Stage 3 CSS features [#91](https://github.com/humanmade/webpack-helpers/pull/91)
 - Include `clean-webpack-plugin` instance in plugins list when using `presets.production()` factory. [#31](https://github.com/humanmade/webpack-helpers/issues/31)
 

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -68,20 +68,27 @@ module.exports = {
 	clean: ( options ) => new CleanPlugin( options ),
 
 	/**
+	 * See https://webpack.js.org/plugins/copy-webpack-plugin/ for full specification.
+	 *
 	 * @typedef CopyPattern
 	 * @type {Object}
-	 * @property {String} from   The absolute directory path from which to copy files.
-	 * @property {String} to     The absolute directory path to which to copy files.
-	 * @property {RegExp} [test] A Regular Expression to limit the files which get copied.
+	 * @property {String}   from        The absolute directory path from which to copy files.
+	 * @property {String}   to          The absolute directory path to which to copy files.
+	 * @property {RegExp}   [test]      A Regular Expression to limit the files which get copied.
+	 * @property {String}   [context]   A path that determines how to interpret the "from" path.
+	 * @property {Function} [transform] Modify file contents on copy.
 	 */
 	/**
 	 * Create a CopyPlugin instance.
 	 *
-	 * @param {CopyPattern[]} patterns  Array of pattern objects ( `{ from, to[, test] }` ).
-	 * @param {Object}        [options] Optional plugin options object.
+	 * See https://webpack.js.org/plugins/copy-webpack-plugin/#options for full
+	 * options object documentation.
+	 *
+	 * @param {Object}        [options]          Optional plugin options object.
+	 * @param {CopyPattern[]} [options.patterns] Array of pattern objects ( `{ from, to[, test] }` ).
 	 * @returns {CopyPlugin} A configured CopyPlugin instance.
 	 */
-	copy: ( patterns, options ) => new CopyPlugin( patterns, options ),
+	copy: ( options ) => new CopyPlugin( options ),
 
 	/**
 	 * Create a BellOnBundleErrorPlugin instance.


### PR DESCRIPTION
`plugins.copy()` now takes a sole object argument specifying a `patterns: []` array key, where before patterns were passed as a first argument.

See [the copy plugin's documentation](https://webpack.js.org/plugins/copy-webpack-plugin/#options) for more information.