### PR TITLE
Support multiconfig in port helper

### DIFF
--- a/src/helpers/with-dynamic-port.js
+++ b/src/helpers/with-dynamic-port.js
@@ -35,42 +35,42 @@ const withDynamicPort = ( port, config ) => {
 	 * the ":port" token with a valid port value if such a token is present, of
 	 * else return the publicPath string as-is.
 	 *
-	 * @param {String} publicPath User-specified public path string.
-	 * @param {Number} port       An HTTP port value.
+	 * @param {String} publicPath   User-specified public path string.
+	 * @param {Number} selectedPort Final HTTP port value.
 	 * @returns {String} Updated publicPath string.
 	 */
-	const getPublicPath = ( publicPath, port ) => {
+	const getPublicPath = ( publicPath, selectedPort ) => {
 		if ( publicPath && portPlaceholder.test( publicPath ) ) {
-			return publicPath.replace( portPlaceholder, `:${ port }` );
+			return publicPath.replace( portPlaceholder, `:${ selectedPort }` );
 		}
 	};
 
 	/**
 	 * Given a port and a configuration object, merge the port into that config.
 	 *
-	 * @param {Object} config Development Webpack configuration object.
-	 * @param {Number} port   HTTP port value.
+	 * @param {Object} config       Development Webpack configuration object.
+	 * @param {Number} selectedPort Final HTTP port value.
 	 * @returns {Object} Updated configuration object.
 	 */
-	const setConfigurationPort = ( config, port ) => ( {
+	const setConfigurationPort = ( config, selectedPort ) => ( {
 		...config,
 		devServer: {
 			...( config.devServer || {} ),
-			port,
+			port: selectedPort,
 		},
 		output: {
 			...( config.output || {} ),
-			publicPath: getPublicPath( config.output.publicPath, port ),
+			publicPath: getPublicPath( config.output.publicPath, selectedPort ),
 		},
 	} );
 
 	// Return config wrapped in a function that will choose an available port
 	// and modify the provided config to operate on that port.
-	return choosePort( port || DEFAULT_PORT ).then( port => {
+	return choosePort( port || DEFAULT_PORT ).then( selectedPort => {
 		if ( Array.isArray( config ) ) {
-			return config.map( subConfig => setConfigurationPort( subConfig, port ) );
+			return config.map( subConfig => setConfigurationPort( subConfig, selectedPort ) );
 		}
-		return setConfigurationPort( config, port );
+		return setConfigurationPort( config, selectedPort );
 	} );
 };
 

--- a/src/helpers/with-dynamic-port.test.js
+++ b/src/helpers/with-dynamic-port.test.js
@@ -184,7 +184,6 @@ describe( 'withDynamicPort', () => {
 		} );
 
 		describe( 'multi-configuration webpack file', () => {
-
 			it( 'uses the provided port, if available', async () => {
 				const config = [
 					{
@@ -233,23 +232,24 @@ describe( 'withDynamicPort', () => {
 						},
 					},
 				];
-				expect( await withDynamicPort( 8081, config ) ).toEqual( [
+				choosePort.mockImplementationOnce( () => Promise.resolve( 8080 ) );
+				expect( await withDynamicPort( 9090, config ) ).toEqual( [
 					{
 						devServer: {
-							port: 8081,
+							port: 8080,
 						},
 						entry: {},
 						output: {
-							publicPath: 'http://localhost:8081',
+							publicPath: 'http://localhost:8080',
 						},
 					},
 					{
 						devServer: {
-							port: 8081,
+							port: 8080,
 						},
 						entry: {},
 						output: {
-							publicPath: 'http://localhost:8081',
+							publicPath: 'http://localhost:8080',
 						},
 					},
 				] );

--- a/src/helpers/with-dynamic-port.test.js
+++ b/src/helpers/with-dynamic-port.test.js
@@ -31,6 +31,21 @@ describe( 'withDynamicPort', () => {
 			expect( withDynamicPort( config ) ).toBe( config );
 			expect( withDynamicPort( 9090, config ) ).toBe( config );
 		} );
+
+		it( 'passes multi-configuration through unchanged', () => {
+			const config = [
+				{
+					entry: {},
+					output: {},
+				},
+				{
+					entry: {},
+					output: {},
+				},
+			];
+			expect( withDynamicPort( config ) ).toBe( config );
+			expect( withDynamicPort( 9091, config ) ).toBe( config );
+		} );
 	} );
 
 	describe( 'when using webpack-dev-server', () => {
@@ -165,6 +180,79 @@ describe( 'withDynamicPort', () => {
 				plugins: [
 					'Plugin goes here',
 				],
+			} );
+		} );
+
+		describe( 'multi-configuration webpack file', () => {
+
+			it( 'uses the provided port, if available', async () => {
+				const config = [
+					{
+						entry: {},
+						output: {},
+					},
+					{
+						entry: {},
+						output: {},
+					},
+				];
+				expect( await withDynamicPort( 8080, config ) ).toEqual( [
+					{
+						devServer: {
+							port: 8080,
+						},
+						entry: {},
+						output: {
+							publicPath: undefined,
+						},
+					},
+					{
+						devServer: {
+							port: 8080,
+						},
+						entry: {},
+						output: {
+							publicPath: undefined,
+						},
+					},
+				] );
+			} );
+
+			it( 'replaces :port or :{provided port number} with the specified port in the publicPath', async () => {
+				const config = [
+					{
+						entry: {},
+						output: {
+							publicPath: 'http://localhost:port',
+						},
+					},
+					{
+						entry: {},
+						output: {
+							publicPath: 'http://localhost:9090',
+						},
+					},
+				];
+				expect( await withDynamicPort( 8081, config ) ).toEqual( [
+					{
+						devServer: {
+							port: 8081,
+						},
+						entry: {},
+						output: {
+							publicPath: 'http://localhost:8081',
+						},
+					},
+					{
+						devServer: {
+							port: 8081,
+						},
+						entry: {},
+						output: {
+							publicPath: 'http://localhost:8081',
+						},
+					},
+				] );
 			} );
 		} );
 	} );


### PR DESCRIPTION
Permit the `withDynamicPort` helper to work upon a [multi-config webpack setup](https://webpack.js.org/configuration/configuration-types/#exporting-multiple-configurations).