### PR TITLE
Correct issue where clean plugin does not invoke a valid constructor

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,10 @@ nav_order: 10
 
 # Changelog
 
+## v0.8.2
+
+- Fix issue where `plugins.clean()` triggered an error. [#106](https://github.com/humanmade/webpack-helpers/pull/106)
+
 ## v0.8.1
 
 - Permit `withDynamicPort` helper to work with multi-configuration Webpack files. [#103](https://github.com/humanmade/webpack-helpers/pull/103)

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -1,5 +1,5 @@
 const { BundleAnalyzerPlugin } = require( 'webpack-bundle-analyzer' );
-const { CleanPlugin } = require( 'clean-webpack-plugin' );
+const { CleanWebpackPlugin } = require( 'clean-webpack-plugin' );
 const { HotModuleReplacementPlugin } = require( 'webpack' );
 const BellOnBundleErrorPlugin = require( 'bell-on-bundler-error-plugin' );
 const CopyPlugin = require( 'copy-webpack-plugin' );
@@ -20,7 +20,7 @@ module.exports = {
 	constructors: {
 		BellOnBundleErrorPlugin,
 		BundleAnalyzerPlugin,
-		CleanPlugin,
+		CleanWebpackPlugin,
 		CopyPlugin,
 		FixStyleOnlyEntriesPlugin,
 		HotModuleReplacementPlugin,
@@ -60,12 +60,12 @@ module.exports = {
 	} ),
 
 	/**
-	 * Create a CleanPlugin instance.
+	 * Create a CleanWebpackPlugin instance.
 	 *
 	 * @param {Object} [options] Optional plugin options object.
-	 * @returns {CleanPlugin} A configured CleanPlugin instance.
+	 * @returns {CleanWebpackPlugin} A configured CleanWebpackPlugin instance.
 	 */
-	clean: ( options ) => new CleanPlugin( options ),
+	clean: ( options ) => new CleanWebpackPlugin( options ),
 
 	/**
 	 * See https://webpack.js.org/plugins/copy-webpack-plugin/ for full specification.

--- a/src/plugins.test.js
+++ b/src/plugins.test.js
@@ -1,0 +1,28 @@
+const plugins = require( './plugins' );
+
+describe( 'plugins', () => {
+	const pluginNames = Object.keys( plugins ).filter( key => key !== 'constructors' );
+
+	// Run some general assertions for each loader.
+	it.each( pluginNames )( '.%s is a function', ( pluginName ) => {
+		expect( plugins[ pluginName ] ).toBeDefined();
+		expect( plugins[ pluginName ] ).toBeInstanceOf( Function );
+	} );
+
+	it.each( pluginNames )( '.%s can be called successfully', ( pluginName ) => {
+		expect( () => {
+			let options;
+			if ( pluginName === 'copy' ) {
+				options = {
+					patterns: [
+						{
+							from: 'source',
+							to: 'dest',
+						},
+					],
+				};
+			}
+			plugins[ pluginName ]( options );
+		} ).not.toThrow();
+	} );
+} );


### PR DESCRIPTION
`CleanPlugin` is undefined, causing `plugins.clean()` to trigger an error since v0.8.0. This corrects the import name to bring in the correct constructor.