### PR TITLE
Add support for filtering entire stylesheet loader chain

### DIFF
--- a/docs/modules/presets.md
+++ b/docs/modules/presets.md
@@ -130,4 +130,6 @@ const config = production.preset(
 );
 ```
 
+The `loaderType` option will be [one of the keys in the `loaders` object](./loaders.html), or else the special key `stylesheet` which will be passed alongside the entire computed stylesheet loader chain. Filter on `stylesheet` to, for example, completely replace the Sass stylesheet support with a different preprocessor like Stylus.
+
 The values of the `loaderType` argument in this callback correspond to the names of the available [loader factory functions](https://humanmade.github.io/webpack-helpers/modules/loaders.html).

--- a/src/loaders.js
+++ b/src/loaders.js
@@ -14,18 +14,14 @@ const deepMerge = require( './helpers/deep-merge' );
 const loaders = {};
 
 const createLoaderFactory = loaderKey => {
-	const getFilteredLoader = ( options, filterMethod ) => {
+	const getFilteredLoader = ( options ) => {
 		// Handle missing options object.
 		if ( typeof options === 'function' ) {
 			return getFilteredLoader( {}, options );
 		}
 
-		// Generate and optionally filter the requested loader definition.
-		const mergedOptions = deepMerge( loaders[ loaderKey ].defaults, options );
-		if ( typeof filterMethod === 'function' ) {
-			return filterMethod( mergedOptions, loaderKey );
-		}
-		return mergedOptions;
+		// Generate the requested loader definition.
+		return deepMerge( loaders[ loaderKey ].defaults, options );
 	};
 
 	return getFilteredLoader;

--- a/src/presets.js
+++ b/src/presets.js
@@ -134,7 +134,7 @@ const development = ( config = {}, options = {} ) => {
 						// Convert small files to data URIs.
 						getFilteredLoader( 'url' ),
 						// Parse styles using SASS, then PostCSS.
-						{
+						filterLoaders( {
 							test: /\.s?css$/,
 							use: [
 								getFilteredLoader( 'style' ),
@@ -154,7 +154,7 @@ const development = ( config = {}, options = {} ) => {
 									},
 								} ),
 							],
-						},
+						}, 'stylesheet' ),
 						// "file" loader makes sure any non-matching assets still get served.
 						// When you `import` an asset you get its filename.
 						getFilteredLoader( 'file' ),
@@ -230,7 +230,7 @@ const development = ( config = {}, options = {} ) => {
  * @returns {webpack.Configuration} A merged Webpack configuration object.
  */
 const production = ( config = {}, options = {} ) => {
-	const { getFilteredLoader } = createFilteringHelpers( options.filterLoaders );
+	const { filterLoaders, getFilteredLoader } = createFilteringHelpers( options.filterLoaders );
 
 	// Determine whether source maps have been requested, and prepare an options
 	// object to be passed to all CSS loaders to honor that request.
@@ -285,7 +285,7 @@ const production = ( config = {}, options = {} ) => {
 						// Convert small files to data URIs.
 						getFilteredLoader( 'url' ),
 						// Parse styles using SASS, then PostCSS.
-						{
+						filterLoaders( {
 							test: /\.s?css$/,
 							use: [
 								// Extract CSS to its own file.
@@ -295,7 +295,7 @@ const production = ( config = {}, options = {} ) => {
 								getFilteredLoader( 'postcss', cssOptions ),
 								getFilteredLoader( 'sass', cssOptions ),
 							],
-						},
+						}, 'stylesheet' ),
 						// "file" loader makes sure any non-matching assets still get served.
 						// When you `import` an asset you get its filename.
 						getFilteredLoader( 'file' ),


### PR DESCRIPTION
There is not currently any good way to replace or act on the complete stylesheet loader chain, or to adjust any properties of the stylesheet loader object such as the `test` regex used to match files. This means that there's effectively no way to inject an alternative stylesheet preprocessor such as Stylus, nor can you (if you ever needed to) adjust the ordering of loaders or remove loaders from the chain.

This PR refactors the presets so that they now run the entire stylesheet loader chain through the same `filterLoaders` method, using the special loaderKey argument `stylesheet`. Documentation on the "overriding presets" page is updated to match.