### PR TITLE
Include OptimizeCssAssetsPlugin in plugins.constructors list

### DIFF
--- a/src/plugins.js
+++ b/src/plugins.js
@@ -26,6 +26,7 @@ module.exports = {
 		HotModuleReplacementPlugin,
 		ManifestPlugin,
 		MiniCssExtractPlugin,
+		OptimizeCssAssetsPlugin,
 		TerserPlugin,
 	},
 


### PR DESCRIPTION
This is used in the file but was not exposed alongside the other plugins