### PR TITLE
Add "smoke test" build to CI, and specify Webpack 4 in "getting started"

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -8,3 +8,6 @@ docs/
 
 # Ignore third-party code
 src/vendor
+
+# The test folder uses ES modules
+test/src

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 *.log
 package-lock.json
+test/build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-script: "npm run lint && npm run test"
+script: "npm run lint && npm run test && npm run test-build"
 node_js:
   - node
   - lts/*

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -17,8 +17,10 @@ npm install --save-dev @humanmade/webpack-helpers
 While this package depends in turn on a number of loaders and plugins, it deliberately does _not_ include `webpack` itself. To install this library along with all its relevant peer dependencies, therefore, you may run the following command:
 
 ```bash
-npm install --save-dev @humanmade/webpack-helpers webpack webpack-cli webpack-dev-server node-sass
+npm install --save-dev @humanmade/webpack-helpers webpack@4 webpack-cli webpack-dev-server node-sass
 ```
+
+Note that we specify Webpack version 4. Support for Webpack 5 is anticipated in the v1.0 release of these helpers, but at present using Webpack 4 provides the most predictable and stable experience across our projects.
 
 ## Configuring Webpack
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -17,7 +17,7 @@ npm install --save-dev @humanmade/webpack-helpers
 While this package depends in turn on a number of loaders and plugins, it deliberately does _not_ include `webpack` itself. To install this library along with all its relevant peer dependencies, therefore, you may run the following command:
 
 ```bash
-npm install --save-dev @humanmade/webpack-helpers webpack@4 webpack-cli webpack-dev-server node-sass
+npm install --save-dev @humanmade/webpack-helpers webpack@4 webpack-cli webpack-dev-server sass
 ```
 
 Note that we specify Webpack version 4. Support for Webpack 5 is anticipated in the v1.0 release of these helpers, but at present using Webpack 4 provides the most predictable and stable experience across our projects.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   ],
   "scripts": {
     "lint": "eslint .",
-    "test": "jest"
+    "test": "jest",
+    "test-build": "webpack --config=test/test-config.js"
   },
   "jest": {
     "setupFilesAfterEnv": [
@@ -32,6 +33,7 @@
     "sass": "^1.26.10",
     "typescript": "^4.0.2",
     "webpack": "^4.35.0",
+    "webpack-cli": "^4.3.1",
     "webpack-dev-server": "^3.7.2"
   },
   "dependencies": {

--- a/test/.babelrc.js
+++ b/test/.babelrc.js
@@ -1,0 +1,1 @@
+module.exports = require( '../babel-preset' );

--- a/test/src/helpers.js
+++ b/test/src/helpers.js
@@ -1,0 +1,6 @@
+export const wait = ( delay ) => new Promise( ( resolve ) => setTimeout( resolve, delay ) );
+
+export const getResults = async () => {
+	await wait( 500 );
+	return 'Results';
+};

--- a/test/src/index.js
+++ b/test/src/index.js
@@ -1,0 +1,8 @@
+import { getResults } from './helpers';
+
+import './style.scss';
+
+( async () => {
+	const results = await getResults();
+	console.log( results );
+} )();

--- a/test/src/style.scss
+++ b/test/src/style.scss
@@ -1,0 +1,11 @@
+div {
+	p {
+		font-family: 'Papyrus';
+
+		&:first-child {
+			color: 'red';
+			font-weight: bold;
+			font-family: 'Comic Sans MS', sans-serif;
+		}
+	}
+}

--- a/test/test-config.js
+++ b/test/test-config.js
@@ -1,0 +1,24 @@
+const { presets, helpers } = require( '../index' );
+
+const { filePath } = helpers;
+
+module.exports = [
+	presets.production( {
+		name: 'production-test',
+		entry: {
+			prod: filePath( 'test/src/index.js' ),
+		},
+		output: {
+			path: filePath( 'test/build/prod' ),
+		}
+	} ),
+	presets.development( {
+		name: 'dev-test',
+		entry: {
+			prod: filePath( 'test/src/index.js' ),
+		},
+		output: {
+			path: filePath( 'test/build/dev' ),
+		},
+	} ),
+];


### PR DESCRIPTION
Following discussion around #147, @igmoweb & I determined we should add a notice to the "getting started" guide

Separately, in order to better validate the MVP functionality of this library, I determined it would be helpful to have a test build within the repo that would be run in CI to flag overtly breaking dependabot upgrades.

As both of these changes relate to the overall compatibility and stability of the library, I'm grouping them together here.