### PR TITLE
Use output.path when inferring publicPath

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,7 @@ nav_order: 10
 
 **New Features**
 
+- Adapt the value of `output.path` when inferring `output.publicPath` in DevServer so that all assets are correctly served in multi-config situations. [#156](https://github.com/humanmade/webpack-helpers/pull/156)
 - Generate a `production-asset-manifest.json` for all production preset builds. [#153](https://github.com/humanmade/webpack-helpers/pull/153) Builds in a multi-configuration setup which target the same output folder will share a manifest. [#154](https://github.com/humanmade/webpack-helpers/pull/154)
 
 **Upgrades & Changes**

--- a/src/helpers/find-in-object.js
+++ b/src/helpers/find-in-object.js
@@ -6,6 +6,9 @@
  * @returns {*} The value of the specified path, or null.
  */
 module.exports = ( obj, objectPath ) => {
+	if ( ! obj ) {
+		return null;
+	}
 	const pathParts = objectPath.split( '.' );
 	let currentLevel = obj;
 	for ( let prop of pathParts ) {

--- a/src/helpers/find-in-object.test.js
+++ b/src/helpers/find-in-object.test.js
@@ -27,4 +27,10 @@ describe( 'findInObject', () => {
 	it( 'returns null if the value is not found', () => {
 		expect( findInObject( obj, 'some.other.value' ) ).toBeNull();
 	} );
+
+	it( 'returns null if input is not an object', () => {
+		expect( findInObject( null, 'some.value' ) ).toBeNull();
+		expect( findInObject( false, 'some.value' ) ).toBeNull();
+		expect( findInObject( 42, 'some.value' ) ).toBeNull();
+	} );
 } );

--- a/src/presets.js
+++ b/src/presets.js
@@ -121,7 +121,6 @@ const development = ( config = {}, options = {} ) => {
 
 		// Inject a default entry point later on if none was specified.
 
-		// `publicPath` should be specified by the consumer.
 		output: {
 			// Provide a default output path.
 			path: filePath( 'build' ),
@@ -131,6 +130,8 @@ const development = ( config = {}, options = {} ) => {
 			filename: '[name].js',
 			// Provide chunk filename. Requires content hash for cache busting.
 			chunkFilename: '[name].[contenthash].chunk.js',
+			// `publicPath` will be inferred as a localhost URL based on output.path
+			// when a devServer.port value is available.
 		},
 
 		module: {

--- a/src/presets.js
+++ b/src/presets.js
@@ -209,9 +209,15 @@ const development = ( config = {}, options = {} ) => {
 	const port = findInObject( config, 'devServer.port' );
 	let publicPath = findInObject( config, 'output.publicPath' );
 	if ( ! publicPath && port ) {
+		// Get the relative path to output.path, without a preceding
+		// slash but including a trailing slash.
+		const relPath = ( findInObject( config, 'output.path' ) || findInObject( devDefaults, 'output.path' ) )
+			.replace( filePath(), '' )
+			.replace( /^\/*/, '' )
+			.replace( /\/*$/, '/' );
 		publicPath = `${
 			findInObject( config, 'devServer.https' ) ? 'https' : 'http'
-		}://localhost:${ port }/`;
+		}://localhost:${ port }/${ relPath }`;
 	}
 
 	// If we had enough value to guess a publicPath, set that path as a default

--- a/src/presets.test.js
+++ b/src/presets.test.js
@@ -99,8 +99,57 @@ describe( 'presets', () => {
 			} );
 		} );
 
-		it.todo( 'assumes a default output.publicPath if a port is specified' );
-		it.todo( 'accounts for the value of devServer.https when inferring publicPath URI' );
+		it( 'assumes a default output.publicPath if a port is specified', () => {
+			const config = development( {
+				devServer: {
+					port: 9090,
+				},
+				entry: 'some-file.js',
+			} );
+			expect( config.output.publicPath ).toBe( 'http://localhost:9090/build/' );
+		} );
+
+		it( 'accounts for the value of devServer.https when inferring publicPath URI', () => {
+			const config = development( {
+				devServer: {
+					https: true,
+					port: 9090,
+				},
+				entry: 'some-file.js',
+			} );
+			expect( config.output.publicPath ).toBe( 'https://localhost:9090/build/' );
+		} );
+
+		it( 'adapts output.path when inferring publicPath URI', () => {
+			const config = development( {
+				devServer: {
+					port: 9090,
+				},
+				entry: 'some-file.js',
+				output: {
+					path: 'some/target',
+				},
+			} );
+			expect( config.output.publicPath ).toBe( 'http://localhost:9090/some/target/' );
+		} );
+
+		it( 'does not assume output.publicPath if a port is not specified', () => {
+			const config = development( {
+				entry: 'some-file.js',
+			} );
+			expect( config.output.publicPath ).toBeUndefined();
+		} );
+
+		it( 'does not overwrite an existing output.publicPath when present', () => {
+			const config = development( {
+				entry: 'some-file.js',
+				output: {
+					publicPath: 'https://my-custom-domain.local/',
+				},
+			} );
+			expect( config.output.publicPath ).toBe( 'https://my-custom-domain.local/' );
+		} );
+
 		it.todo( 'injects a ManifestPlugin if publicPath can be inferred and no manifest plugin is already present' );
 		it.todo( 'does not inject a ManifestPlugin if publicPath cannot be inferred' );
 		it.todo( 'does not inject a ManifestPlugin if a manifest plugin is already present' );


### PR DESCRIPTION
In a multiple-config Webpack setup, builds to two different output directories appear to both need a specified, unique publicPath in order for those bundles to be accessible as expected within the dev server.

To ensure that default usage creates bundles which can be loaded correctly in a multi-config DevServer environment, we adapt the value of output.path (stripping out the filePath cwd base) for use as a subdirectory within the in-memory virtual filesystem of the DevServer.

I encountered this behavior while testing v0.10-beta.1, and in a happy coincidence fixing it also fills in some of our `.todo` tests...