### PR TITLE
Abstract inferring publicPath, fix withDynamicPort

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,10 @@ nav_order: 10
 
 # Changelog
 
+## v0.10.2
+
+- Correctly infer a default publicPath when using `withDynamicPort` helper. [#161](https://github.com/humanmade/webpack-helpers/pull/161)
+
 ## v0.10.1
 
 - Update WordPress `externals` object to match latest bundled scripts. [#160](https://github.com/humanmade/webpack-helpers/pull/160)

--- a/src/helpers/infer-public-path.js
+++ b/src/helpers/infer-public-path.js
@@ -1,0 +1,27 @@
+const filePath = require( './file-path' );
+const findInObject = require( './find-in-object' );
+
+/**
+ * Infer the public path based on the defined output path.
+ *
+ * @param {webpack.Configuration} config     Webpack configuration object.
+ * @param {Number}                port       Port to use for webpack-dev-server.
+ * @param {Object}                [defaults] Optional config default values.
+ * @return {String} Public path.
+ */
+const inferPublicPath = ( config, port, defaults = {} ) => {
+	const protocol = findInObject( config, 'devServer.https' ) ? 'https' : 'http';
+
+	const outputPath = findInObject( config, 'output.path' ) || findInObject( defaults, 'output.path' );
+
+	// Get the relative path to output.path, without a preceding
+	// slash but including a trailing slash.
+	const relPath = outputPath
+		.replace( filePath(), '' )
+		.replace( /^\/*/, '' )
+		.replace( /\/*$/, '/' );
+
+	return `${ protocol }://localhost:${ port }/${ relPath }`;
+};
+
+module.exports = inferPublicPath;

--- a/src/helpers/with-dynamic-port.js
+++ b/src/helpers/with-dynamic-port.js
@@ -4,8 +4,21 @@
  * and use an available port on your host system when using webpack-dev-server.
  */
 const choosePort = require( './choose-port' );
+const filePath = require( './file-path' );
+const findInObject = require( './find-in-object' );
+const inferPublicPath = require( './infer-public-path' );
 
 const DEFAULT_PORT = 9090;
+
+/**
+ * Default development environment-oriented Webpack options.
+ */
+const devDefaults = {
+	output: {
+		// Provide a default output path.
+		path: filePath( 'build' ),
+	},
+};
 
 /**
  *
@@ -35,11 +48,16 @@ const withDynamicPort = ( port, config ) => {
 	 * the ":port" token with a valid port value if such a token is present, of
 	 * else return the publicPath string as-is.
 	 *
-	 * @param {String} publicPath   User-specified public path string.
+	 * @param {Object} config       Development Webpack configuration object.
 	 * @param {Number} selectedPort Final HTTP port value.
 	 * @returns {String} Updated publicPath string.
 	 */
-	const getPublicPath = ( publicPath, selectedPort ) => {
+	const getPublicPath = ( config, selectedPort ) => {
+		let publicPath = findInObject( config, 'output.publicPath' );
+		if ( ! publicPath && port ) {
+			publicPath = inferPublicPath( config, port, devDefaults );
+		}
+
 		if ( publicPath && portPlaceholder.test( publicPath ) ) {
 			return publicPath.replace( portPlaceholder, `:${ selectedPort }` );
 		}
@@ -60,7 +78,7 @@ const withDynamicPort = ( port, config ) => {
 		},
 		output: {
 			...( config.output || {} ),
-			publicPath: getPublicPath( config.output.publicPath, selectedPort ),
+			publicPath: getPublicPath( config, selectedPort ),
 		},
 	} );
 

--- a/src/helpers/with-dynamic-port.test.js
+++ b/src/helpers/with-dynamic-port.test.js
@@ -72,7 +72,7 @@ describe( 'withDynamicPort', () => {
 				},
 				entry: {},
 				output: {
-					publicPath: undefined,
+					publicPath: 'http://localhost:8080/build/',
 				},
 			} );
 		} );
@@ -88,7 +88,7 @@ describe( 'withDynamicPort', () => {
 				},
 				entry: {},
 				output: {
-					publicPath: undefined,
+					publicPath: 'http://localhost:9090/build/',
 				},
 			} );
 		} );
@@ -202,7 +202,7 @@ describe( 'withDynamicPort', () => {
 						},
 						entry: {},
 						output: {
-							publicPath: undefined,
+							publicPath: 'http://localhost:8080/build/',
 						},
 					},
 					{
@@ -211,7 +211,7 @@ describe( 'withDynamicPort', () => {
 						},
 						entry: {},
 						output: {
-							publicPath: undefined,
+							publicPath: 'http://localhost:8080/build/',
 						},
 					},
 				] );

--- a/src/presets.js
+++ b/src/presets.js
@@ -2,6 +2,7 @@ const { devServer, stats } = require( './config' );
 const deepMerge = require( './helpers/deep-merge' );
 const filePath = require( './helpers/file-path' );
 const findInObject = require( './helpers/find-in-object' );
+const inferPublicPath = require( './helpers/infer-public-path' );
 const isInstalled = require( './helpers/is-installed' );
 const loaders = require( './loaders' );
 const plugins = require( './plugins' );
@@ -210,15 +211,7 @@ const development = ( config = {}, options = {} ) => {
 	const port = findInObject( config, 'devServer.port' );
 	let publicPath = findInObject( config, 'output.publicPath' );
 	if ( ! publicPath && port ) {
-		// Get the relative path to output.path, without a preceding
-		// slash but including a trailing slash.
-		const relPath = ( findInObject( config, 'output.path' ) || findInObject( devDefaults, 'output.path' ) )
-			.replace( filePath(), '' )
-			.replace( /^\/*/, '' )
-			.replace( /\/*$/, '/' );
-		publicPath = `${
-			findInObject( config, 'devServer.https' ) ? 'https' : 'http'
-		}://localhost:${ port }/${ relPath }`;
+		publicPath = inferPublicPath( config, port, devDefaults );
 	}
 
 	// If we had enough value to guess a publicPath, set that path as a default


### PR DESCRIPTION
This PR addresses #159.

Changes included:
- Abstract the logic to infer the public path based on the defined output path into a new function (and file), `inferPublicPath`.
- Use the new function in the `presets.development` factory.
- Use the new function in the `withDynamicPort` helper, and fix #159.