### PR TITLE
Port shared seed code from prod preset to dev

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,10 @@ nav_order: 10
 
 # Changelog
 
+## v0.10.3
+
+- **Potentially Breaking:** Extend auto-shared seeds for manifest generation to `development` preset. The upshot of this is that multi-config setups in development don't need custom manifest configurations to use the same manifest--they'll do so automatically. [#166](https://github.com/humanmade/webpack-helpers/pull/166)
+
 ## v0.10.2
 
 - Correctly infer a default publicPath when using `withDynamicPort` helper. [#161](https://github.com/humanmade/webpack-helpers/pull/161)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@humanmade/webpack-helpers",
   "public": true,
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Reusable Webpack configuration components & related helper utilities.",
   "main": "index.js",
   "author": "Human Made",

--- a/src/presets.js
+++ b/src/presets.js
@@ -225,7 +225,11 @@ const development = ( config = {}, options = {} ) => {
 		const hasManifestPlugin = plugins.findExistingInstance( config.plugins, ManifestPlugin );
 		// Add a manifest with the inferred publicPath if none was present.
 		if ( ! hasManifestPlugin ) {
-			devDefaults.plugins.push( plugins.manifest() );
+			const outputPath = ( config.output && config.output.path ) || devDefaults.output.path;
+			devDefaults.plugins.push( plugins.manifest( {
+				fileName: 'asset-manifest.json',
+				seed: getSeedByDirectory( outputPath ),
+			} ) );
 		}
 	}
 

--- a/src/presets.test.js
+++ b/src/presets.test.js
@@ -150,9 +150,106 @@ describe( 'presets', () => {
 			expect( config.output.publicPath ).toBe( 'https://my-custom-domain.local/' );
 		} );
 
-		it.todo( 'injects a ManifestPlugin if publicPath can be inferred and no manifest plugin is already present' );
-		it.todo( 'does not inject a ManifestPlugin if publicPath cannot be inferred' );
-		it.todo( 'does not inject a ManifestPlugin if a manifest plugin is already present' );
+		it( 'injects a ManifestPlugin if publicPath can be inferred and no manifest plugin is already present', () => {
+			const { ManifestPlugin } = plugins.constructors;
+			const config = development( {
+				devServer: {
+					port: 8080
+				},
+				entry: {
+					main: 'some-file.css',
+				},
+			} );
+			expect( config.plugins ).toEqual( expect.arrayContaining( [
+				expect.any( plugins.constructors.ManifestPlugin ),
+			] ) );
+			const manifestPlugins = config.plugins.filter( filterPlugins( ManifestPlugin ) );
+			expect( manifestPlugins.length ).toBe( 1 );
+			expect( manifestPlugins[ 0 ].options.fileName ).toEqual( 'asset-manifest.json' );
+		} );
+
+		it( 'does not inject a ManifestPlugin if publicPath cannot be inferred', () => {
+			const config = development( {
+				entry: {
+					main: 'some-file.css',
+				},
+			} );
+			expect( config.output ).not.toHaveProperty( 'publicPath' );
+			expect( config.plugins ).toEqual( expect.not.arrayContaining( [
+				expect.any( plugins.constructors.ManifestPlugin ),
+			] ) );
+		} );
+
+		it( 'does not override or duplicate existing ManifestPlugin instances', () => {
+			const { ManifestPlugin } = plugins.constructors;
+			const config = development( {
+				entry: {
+					main: 'some-file.css',
+				},
+				devServer: {
+					port: 8080
+				},
+				plugins: [
+					plugins.manifest( {
+						fileName: 'custom-manifest.json',
+					} ),
+				],
+			} );
+			expect( config.plugins ).toEqual( expect.arrayContaining( [
+				expect.any( plugins.constructors.ManifestPlugin ),
+			] ) );
+			const manifestPlugins = config.plugins.filter( filterPlugins( ManifestPlugin ) );
+			expect( manifestPlugins.length ).toBe( 1 );
+			expect( manifestPlugins[ 0 ].options.fileName ).toEqual( 'custom-manifest.json' );
+		} );
+
+		it( 'uses a consistent seed for manifests generated in the same directory', () => {
+			const { ManifestPlugin } = plugins.constructors;
+			const [ manifest1 ] = development( {
+				entry: { main: 'some-file' },
+				output: {
+					path: '/some/path',
+				},
+				devServer: {
+					port: 8080,
+				},
+			} )
+				.plugins
+				.filter( filterPlugins( ManifestPlugin ) );
+			const [ manifest2 ] = development( {
+				entry: { main: 'some-file' },
+				output: {
+					path: '/some/path',
+				},
+				devServer: {
+					port: 8080,
+				},
+			} )
+				.plugins
+				.filter( filterPlugins( ManifestPlugin ) );
+			const [ manifest3 ] = development( {
+				entry: { main: 'some-file' },
+				output: {
+					path: '/some/DIFFERENT/path',
+				},
+				devServer: {
+					port: 8080,
+				},
+			} )
+				.plugins
+				.filter( filterPlugins( ManifestPlugin ) );
+			// Ensure the two builds in the same folder use the same seed.
+			expect( manifest1.options.seed ).toEqual( {} );
+			expect( manifest2.options.seed ).toEqual( {} );
+			expect( manifest1 ).not.toBe( manifest2 );
+			expect( manifest1.options.seed ).toBe( manifest2.options.seed );
+			// Ensure the build to the other output.path uses a different seed.
+			expect( manifest3 ).not.toBe( manifest1 );
+			expect( manifest3 ).not.toBe( manifest2 );
+			expect( manifest3.options.seed ).toEqual( {} );
+			expect( manifest3.options.seed ).not.toBe( manifest2.options.seed );
+			expect( manifest3.options.seed ).not.toBe( manifest1.options.seed );
+		} );
 
 		it( 'permits filtering the computed output of individual loaders', () => {
 			const config = development( {


### PR DESCRIPTION
This allows development presets to automatically share manifests, with the same logic production presets already use. Also adds tests for this behavior.

Largely this introduces nothing new: Just some modifications to a copy of the existing code to address dev-specific differences (i.e. inferred publicPath).