### PR TITLE
Pin run-parallel library to avoid node v10 failure

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,7 @@ nav_order: 10
 ## v0.10.3
 
 - **Potentially Breaking:** Extend auto-shared seeds for manifest generation to `development` preset. The upshot of this is that multi-config setups in development don't need custom manifest configurations to use the same manifest--they'll do so automatically. [#166](https://github.com/humanmade/webpack-helpers/pull/166)
+- Internal: Pin `run-parallel` subdependency (required by `copy-webpack-plugin`) to 1.1.9 to guarantee Node v10 compatibility. [#167](https://github.com/humanmade/webpack-helpers/pull/167)
 
 ## v0.10.2
 

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "postcss-flexbugs-fixes": "^5.0.2",
     "postcss-loader": "^4.1.0",
     "postcss-preset-env": "^6.7.0",
+    "run-parallel": "1.1.9",
     "sass-loader": "^10.0.2",
     "signal-exit": "^3.0.2",
     "style-loader": "^2.0.0",


### PR DESCRIPTION
The `run-parallel` package introduced in v1.2.0 a new dependency on `queue-microtask`, which is not written to support Node v10. Since v1.1.9 of `run-parallel` still satisfies the semver range of the library which depends upon the parallel execution (part of `copy-webpack-plugin`), pinning this dependency manually should restore Node v10 functionality.