### PR TITLE
Require webpack cli v3 to fix webpack-dev-server error

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,7 @@ nav_order: 10
 
 ## v0.10.3
 
+- Require Webpack CLI version 3—v4 is not yet supported. [#168](https://github.com/humanmade/webpack-helpers/pull/168)
 - **Potentially Breaking:** Extend auto-shared seeds for manifest generation to `development` preset. The upshot of this is that multi-config setups in development don't need custom manifest configurations to use the same manifest--they'll do so automatically. [#166](https://github.com/humanmade/webpack-helpers/pull/166)
 
 ## v0.10.2

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,7 +8,7 @@ nav_order: 10
 
 ## v0.10.3
 
-- Require Webpack CLI version 3—v4 is not yet supported. [#168](https://github.com/humanmade/webpack-helpers/pull/168)
+- **Potentially Breaking**: Require Webpack CLI version 3 to avoid DevServer issues. If your project uses v4, run `npm install webpack-cli@3` to downgrade. [#168](https://github.com/humanmade/webpack-helpers/pull/168)
 - **Potentially Breaking:** Extend auto-shared seeds for manifest generation to `development` preset. The upshot of this is that multi-config setups in development don't need custom manifest configurations to use the same manifest--they'll do so automatically. [#166](https://github.com/humanmade/webpack-helpers/pull/166)
 
 ## v0.10.2

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -17,7 +17,7 @@ npm install --save-dev @humanmade/webpack-helpers
 While this package depends in turn on a number of loaders and plugins, it deliberately does _not_ include `webpack` itself. To install this library along with all its relevant peer dependencies, therefore, you may run the following command:
 
 ```bash
-npm install --save-dev @humanmade/webpack-helpers webpack@4 webpack-cli webpack-dev-server sass
+npm install --save-dev @humanmade/webpack-helpers webpack@4 webpack-cli@3 webpack-dev-server sass
 ```
 
 Note that we specify Webpack version 4. Support for Webpack 5 is anticipated in the v1.0 release of these helpers, but at present using Webpack 4 provides the most predictable and stable experience across our projects.

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "sass": "^1.32.4",
     "typescript": "^4.0.2",
     "webpack": "^4.46.0",
-    "webpack-cli": "^4.3.1",
+    "webpack-cli": "^3.3.12",
     "webpack-dev-server": "^3.11.2"
   },
   "dependencies": {
@@ -73,7 +73,7 @@
     "sass": "*",
     "typescript": "*",
     "webpack": "^4.0.0",
-    "webpack-cli": "*",
+    "webpack-cli": "^3.0.0",
     "webpack-dev-server": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "scripts": {
     "lint": "eslint .",
     "test": "jest",
-    "test-build": "rm -rf test/build && webpack --config=test/test-config.js"
+    "test-build": "rm -rf test/build && webpack --config=test/test-config.js",
+    "test-dev-server": "webpack-dev-server --config=test/test-config.js"
   },
   "jest": {
     "setupFilesAfterEnv": [


### PR DESCRIPTION
Following up on discussion with @alwaysblank in Slack, there appears to be an incompatibility with Webpack Dev Server and Webpack CLI v4 where it will report errors or fail to start in some situations. Requiring v3 of the CLI library appears to resolve the issue.

This is arguably a breaking-enough change (it would show a peerDep error on `npm install` for a configured project that does use CLI v4) that we should ship a v0.11, but I've earmarked it for v0.10 for now. Thoughts?