### PR TITLE
Fix handling of RTL files in the manifest

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,8 +6,9 @@ nav_order: 10
 
 # Changelog
 
-## v0.10.3
+## Next
 
+- Correctly output `.rtl.css` manifest entries when using the `WebpackRTLPlugin`. [#171](https://github.com/humanmade/webpack-helpers/pull/171)
 - **Potentially Breaking**: Require Webpack CLI version 3 to avoid DevServer issues. If your project uses v4, run `npm install webpack-cli@3` to downgrade. [#168](https://github.com/humanmade/webpack-helpers/pull/168)
 - **Potentially Breaking:** Extend auto-shared seeds for manifest generation to `development` preset. The upshot of this is that multi-config setups in development don't need custom manifest configurations to use the same manifest--they'll do so automatically. [#166](https://github.com/humanmade/webpack-helpers/pull/166)
 - Internal: Pin `run-parallel` subdependency (required by `copy-webpack-plugin`) to 1.1.9 to guarantee Node v10 compatibility. [#167](https://github.com/humanmade/webpack-helpers/pull/167)

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -129,6 +129,14 @@ module.exports = {
 	manifest: ( options = {} ) => new ManifestPlugin( {
 		fileName: 'asset-manifest.json',
 		writeToFileEmit: true,
+		map: ( file ) => {
+			// Make sure an RTL file has a separate entry in the manifest.
+			if ( /\.rtl\.css$/.test( file.path ) ) {
+				file.name = file.name.replace( '.css', '.rtl.css' );
+			}
+
+			return file;
+		},
 		...options,
 	} ),
 

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -130,8 +130,9 @@ module.exports = {
 		fileName: 'asset-manifest.json',
 		writeToFileEmit: true,
 		map: ( file ) => {
-			// Make sure an RTL file has a separate entry in the manifest.
-			if ( /\.rtl\.css$/.test( file.path ) ) {
+			// Work around https://github.com/romainberger/webpack-rtl-plugin/issues/14
+			// to make sure an RTL file has a separate entry in the manifest.
+			if ( ( /\.rtl\.css$/ ).test( file.path ) ) {
 				file.name = file.name.replace( '.css', '.rtl.css' );
 			}
 


### PR DESCRIPTION
When using the WebpackRTLPlugin the manifest doesn't produce entries for both the original and the RTL file. This results in the wrong file being loaded. This is caused by the fact that both files are in the same chunk.

There is an issue tracking this on the WebpackRTLPlugin: https://github.com/romainberger/webpack-rtl-plugin/issues/14

This commit includes a workaround. By providing a `map` function to the manifest plugin we can change the name when we're dealing with an RTL file. That results in two entries in the eventual manifest.

cc @kadamwhite, @alwaysblank 