### PR TITLE
Disable sass css compression to allow comments

### DIFF
--- a/src/loaders.js
+++ b/src/loaders.js
@@ -96,7 +96,9 @@ loaders.postcss.defaults = {
 loaders.sass.defaults = {
 	loader: require.resolve( 'sass-loader' ),
 	options: {
-		sassOptions: {},
+		sassOptions: {
+			outputStyle: 'expanded'
+		},
 	},
 };
 


### PR DESCRIPTION
Potentially resolves as issue where autoprefixer arguments passed as comments are stripped and then ignored. 

Inspired by:
- https://github.com/symfony/webpack-encore/issues/638
- https://github.com/symfony/webpack-encore/pull/639

Since our CSS is compressed by other tools, we don't need sass to do it anyway.