### PR TITLE
Add @wordpress/icons package as externals

### DIFF
--- a/src/__snapshots__/externals.test.js.snap
+++ b/src/__snapshots__/externals.test.js.snap
@@ -29,6 +29,7 @@ Object {
   "@wordpress/hooks": "wp.hooks",
   "@wordpress/html-entities": "wp.htmlEntities",
   "@wordpress/i18n": "wp.i18n",
+  "@wordpress/icons": "wp.icons",
   "@wordpress/is-shallow-equal": "wp.isShallowEqual",
   "@wordpress/keyboard-shortcuts": "wp.keyboardShortcuts",
   "@wordpress/keycodes": "wp.keycodes",

--- a/src/externals.js
+++ b/src/externals.js
@@ -37,6 +37,7 @@ module.exports = [
 	'hooks',
 	'html-entities',
 	'i18n',
+	'icons',
 	'is-shallow-equal',
 	'keyboard-shortcuts',
 	'keycodes',


### PR DESCRIPTION
Would be good to support this package: https://github.com/WordPress/gutenberg/blob/trunk/packages/icons