### PR TITLE
Add @wordpress/icons to externals

### DIFF
--- a/src/externals.js
+++ b/src/externals.js
@@ -36,6 +36,7 @@ module.exports = [
 	'format-library',
 	'hooks',
 	'html-entities',
+	'icons',
 	'i18n',
 	'is-shallow-equal',
 	'keyboard-shortcuts',


### PR DESCRIPTION
Trying to switch a project to webpack helpers and spotted that the WordPress icons package is not available in the externals. 