### PR TITLE
Provide preset config as filter argument when appropriate

### DIFF
--- a/docs/modules/loaders.md
+++ b/docs/modules/loaders.md
@@ -10,7 +10,7 @@ nav_order: 3
 
 This module provides functions that generate configurations for commonly-needed Webpack loaders. Use them within the `.module.rules` array, or use `presets.development()`/`presets.production()` to opt-in to some opinionated defaults.
 
-- `loaders.assets()`: Return a configured Webpack module loader rule for [`asset` modules](https://webpack.js.org/guides/asset-modules/#inlining-assets) which will be inlined if small enough.
+- `loaders.asset()`: Return a configured Webpack module loader rule for [`asset` modules](https://webpack.js.org/guides/asset-modules/#inlining-assets) which will be inlined if small enough.
 - `loaders.js()`: Return a configured Webpack module loader rule for `js-loader`.
 - `loaders.ts()`: Return a configured Webpack module loader rule for `ts-loader`.
 - `loaders.style()`: Return a configured Webpack module loader rule for `style-loader`.

--- a/docs/modules/loaders.md
+++ b/docs/modules/loaders.md
@@ -45,15 +45,24 @@ module.exports = {
 };
 ```
 
-To alter the configuration for a loader prior to use within a preset, you may mutate the `.defaults` property on the loader method.
+To alter the configuration for a loader prior to use within a preset, you may either [filter](https://humanmade.github.io/webpack-helpers/reference/hooks.html) the default loader options, or the final merged loader configuration.
 
 ```js
 const { helpers, loaders, presets } = require( '@humanmade/webpack-helpers' );
+const { addFilter } = helpers;
 
-// Mutate the loader defaults.
-loaders.js.defaults.include = helpers.filePath( 'themes/my-theme/src' );
-loaders.css.defaults.options.url = false;
+// Adjust the loader defaults.
+addFilter( 'loaders/js/defaults', ( defaults ) => ( {
+	...defaults,
+	include: helpers.filePath( 'themes/my-theme/src' ),
+} ) );
 
+addFilter( 'loaders/css/defaults', ( defaults ) => {
+	defaults.options.url = false;
+	return defaults;
+} );
+
+// The above customizations will now apply to all calls to loader or preset factories.
 module.exports = presets.development( { /* ... */ } );
 ```
 

--- a/docs/modules/loaders.md
+++ b/docs/modules/loaders.md
@@ -17,7 +17,7 @@ This module provides functions that generate configurations for commonly-needed 
 - `loaders.css()`: Return a configured Webpack module loader rule for `css-loader`.
 - `loaders.postcss()`: Return a configured Webpack module loader rule for `postcss-loader`.
 - `loaders.sass()`: Return a configured Webpack module loader rule for `sass-loader`.
-- `loaders.sourcemaps()`: Return a configured Webpack module loader rule for `source-map-loader`.
+- `loaders.sourcemap()`: Return a configured Webpack module loader rule for `source-map-loader`.
 - `loaders.resource()`: Return a configured Webpack module loader rule for [`asset/resource` modules](https://webpack.js.org/guides/asset-modules/#resource-assets).
 
 ## Customizing Loaders

--- a/docs/modules/loaders.md
+++ b/docs/modules/loaders.md
@@ -6,19 +6,23 @@ nav_order: 3
 
 # Loaders Module
 
-`const { loaders } = require( '@humanmade/webpack-helpers' );`
+```js
+const { loaders } = require( '@humanmade/webpack-helpers' );
+```
 
 This module provides functions that generate configurations for commonly-needed Webpack loaders. Use them within the `.module.rules` array, or use `presets.development()`/`presets.production()` to opt-in to some opinionated defaults.
 
-- `loaders.asset()`: Return a configured Webpack module loader rule for [`asset` modules](https://webpack.js.org/guides/asset-modules/#inlining-assets) which will be inlined if small enough.
-- `loaders.js()`: Return a configured Webpack module loader rule for `js-loader`.
-- `loaders.ts()`: Return a configured Webpack module loader rule for `ts-loader`.
-- `loaders.style()`: Return a configured Webpack module loader rule for `style-loader`.
+- `loaders.asset()`: Return a configured Webpack module loader rule for [`asset` modules](https://webpack.js.org/guides/asset-modules/#inlining-assets) which will be inlined when small enough.
 - `loaders.css()`: Return a configured Webpack module loader rule for `css-loader`.
+- `loaders.js()`: Return a configured Webpack module loader rule for `js-loader`.
 - `loaders.postcss()`: Return a configured Webpack module loader rule for `postcss-loader`.
+- `loaders.resource()`: Return a configured Webpack module loader rule for [`asset/resource` modules](https://webpack.js.org/guides/asset-modules/#resource-assets).
 - `loaders.sass()`: Return a configured Webpack module loader rule for `sass-loader`.
 - `loaders.sourcemap()`: Return a configured Webpack module loader rule for `source-map-loader`.
-- `loaders.resource()`: Return a configured Webpack module loader rule for [`asset/resource` modules](https://webpack.js.org/guides/asset-modules/#resource-assets).
+- `loaders.style()`: Return a configured Webpack module loader rule for `style-loader`.
+- `loaders.ts()`: Return a configured Webpack module loader rule for `ts-loader`.
+
+The output from these loaders can optionally be [filtered](https://humanmade.github.io/webpack-helpers/reference/hooks.html).
 
 ## Customizing Loaders
 
@@ -53,4 +57,4 @@ loaders.css.defaults.options.url = false;
 module.exports = presets.development( { /* ... */ } );
 ```
 
-These loaders are also used by the [presets](https://humanmade.github.io/webpack-helpers/modules/presets.html) methods described above. To adjust the behavior of a loader for a specific configuration generated using a preset, you may pass a second argument to the preset defining a filter function which can modify loader options as they are computed. See ["Customizing Presets"](https://humanmade.github.io/webpack-helpers/modules/presets.html#customizing-presets) for more information.
+These loaders are also used by the [presets](https://humanmade.github.io/webpack-helpers/modules/presets.html) methods described above. To adjust the behavior of a loader for a specific configuration generated using a preset, see ["Customizing Presets"](https://humanmade.github.io/webpack-helpers/modules/presets.html#customizing-presets).

--- a/docs/modules/presets.md
+++ b/docs/modules/presets.md
@@ -161,10 +161,4 @@ module.exports = [
 ];
 ```
 
-#### Hooks list
-
-- `loader/{loader name}`: Adjust the final output of [any of the methods on the `loaders` object](./loaders.html), for example `loader/sass` or `loader/js`.
-- `loader/{loader name}/default`: Alter the default values before passing it to the loader configuration merge function.
-- `loader/postcss/plugins`: Filter the default list of PostCSS plugins used by the PostCSS loader.
-- `loader/postcss/preset-env`: Filter the default configuration object passed to the PostCSS Preset Env plugin.
-- `presets/stylesheet-loaders`: Filter the computed chain of stylesheet loaders output by the preset factories. This hook receives a second argument `environment` which will show either "production" or "development," to permit per-environment filtering, and a third argument `configuration` which contains the object passed to the preset factory.
+For more information, see [the full hooks reference.](https://humanmade.github.io/webpack-helpers/reference/hooks.html).

--- a/docs/modules/presets.md
+++ b/docs/modules/presets.md
@@ -113,7 +113,8 @@ module.exports.optimization.minimizer = [
 Array values are _merged_ when processing a preset, not overwritten. This allows you to easily add plugins, but it can make it hard to _remove_ values from array properties like the module loader rules or plugins list. To change loader configuration options without completely removing a loader, or adjust loaders deep within a generated configuration tree, this library provides a `addFilter` helper function. `addFilter()` lets you register a callback which can transform the value of each computed loader, as well as some other useful configuration values.
 
 ```js
-const { addFilter } = require( 'helpers' );
+const { helpers, presets } = require( '@humanmade/webpack-helpers' );
+const { addFilter } = helpers;
 
 // Intercept the "sass" loader and replace it with a Stylus loader.
 addFilter( 'loaders/sass', () => {
@@ -128,15 +129,42 @@ addFilter( 'presets/stylesheet-loaders', ( loader ) => {
 } );
 
 // Now, use the preset as normal and it will pick up Stylus files instead!
-const config = production.preset(
+const config = presets.production(
 	{ /* ...normal configuration options as described above ... */ }
 );
 ```
 
-Available hooks:
+If you are using a multi-configuration Webpack setup where the config file exports an array of individual configurations, you may wish to filter a loader, preset chain, or other value for only one of those configuration objects. To permit this, each filter callback will be passed the preset's configuration object as a final argument when the filter or loader is called in the context of a preset. For example,
+
+```js
+const { helpers, externals, presets } = require( '@humanmade/webpack-helpers' );
+const { addFilter } = helpers;
+
+// Do not use the JS loader in the frontend build.
+addFilter( 'presets/js', ( loader, config ) => {
+	if ( config.name === 'frontend' ) {
+		return null;
+	}
+	return frontend;
+} );
+
+module.exports = [
+	presets.production( {
+		name: 'frontend',
+		// ...
+	} ),
+	presets.production( {
+		name: 'editor',
+		externals,
+		// ...
+	} ),
+];
+```
+
+#### Hooks list
 
 - `loader/{loader name}`: Adjust the final output of [any of the methods on the `loaders` object](./loaders.html), for example `loader/sass` or `loader/js`.
 - `loader/{loader name}/default`: Alter the default values before passing it to the loader configuration merge function.
-- `loader/postcss/plugins`: Filter the list of PostCSS plugins used by that specific loader.
-- `loader/postcss/preset-env`: Filter the configuration object passed to the PostCSS Preset Env plugin.
-- `presets/stylesheet-loaders`: Filter the computed chain of stylesheet loaders output by the preset factories. This hook receives a second argument `environment` which will show either "production" or "development," to permit per-environment filtering.
+- `loader/postcss/plugins`: Filter the default list of PostCSS plugins used by the PostCSS loader.
+- `loader/postcss/preset-env`: Filter the default configuration object passed to the PostCSS Preset Env plugin.
+- `presets/stylesheet-loaders`: Filter the computed chain of stylesheet loaders output by the preset factories. This hook receives a second argument `environment` which will show either "production" or "development," to permit per-environment filtering, and a third argument `configuration` which contains the object passed to the preset factory.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,0 +1,10 @@
+---
+title: Reference
+has_children: true
+permalink: /reference
+nav_order: 3
+---
+
+# Reference Documentation
+
+Code-level documentation of specific components of `@humanmade/webpack-helpers`.

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -103,6 +103,12 @@ Filter the [`postcss-preset-env` plugin's](https://github.com/csstools/postcss-p
 
 Unlike the hooks above, callbacks added to this filter do not receive the preset configuration object.
 
+**Arguments:**
+
+ name | type | description
+----- | ---- | ------
+`pluginOptions` | `Object` | `postcss-preset-env` plugin options object.
+
 ```js
 addFilter( 'loaders/postcss/preset-env', ( pluginOptions ) => {
 	// Filter the PostCSS Preset Env plugin options.

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -1,0 +1,111 @@
+---
+title: Filter Hooks
+parent: Reference
+nav_order: 1
+---
+
+# Filter Hooks
+
+These hooks are provided by Webpack Helpers to customize the behavior of a specific loader or preset within your project.
+
+`{loader name}` in the below filters may be any slug for an available [loader](https://humanmade.github.io/webpack-helpers/modules/loaders.html): `asset`, `css`, `js`, `postcss`, `resource`, `sass`, `sourcemap`, `style`, and `ts`.
+
+Remember to always return a value from a filter callback.
+
+## `loaders/{loader name}`
+
+Filter the full loader configuration object after merging any user-provided options with the (filtered) defaults.
+
+When called in the context of a preset, the callback will receive the preset factory's configuration object as a second argument.
+
+**Arguments:**
+
+ name | type | description
+----- | ---- | ------
+`loader` | `Object` | Loader configuration object.
+`config` | `Object` or `null` | Preset configuration object if a preset is being rendered, else `null`.
+
+Return `null` from the callback to remove this loader from preset-generated configurations.
+
+```js
+addFilter( 'loaders/{loader name}', ( loader, config = null ) => {
+	// Filter the loader definition globally or based on the specific
+	// configuration options provided to a preset factory.
+	return loader;
+} );
+```
+
+## `loaders/{loader name}/defaults`
+
+Adjust the default values used to define a given loader configuration.
+
+When called in the context of a preset, the callback will receive the preset factory's configuration object as a second argument.
+
+**Arguments:**
+
+ name | type | description
+----- | ---- | ------
+`defaults` | `Object` | Defaults for this specific loader.
+`config` | `Object` or `null` | Preset configuration object if a preset is being rendered, else `null`.
+
+```js
+addFilter( 'loaders/{loader name}/defaults', ( defaults, config = null ) => {
+	// Filter the loader's defaults globally or based on the specific
+	// configuration options provided to a preset factory.
+	return defaults;
+} );
+```
+
+## `presets/stylesheet-loaders`
+
+Filter the loaders used to process stylesheet imports when building your project.
+
+The callback will receive the environment type of the preset being rendered as its second argument, and the preset's configuration object argument as a third argument.
+
+**Arguments:**
+
+ name | type | description
+----- | ---- | ------
+`loader` | `Object` | Combined stylesheet loader rule.
+`environment` | `string` | `'development'` or `'production'`.
+`config` | `Object` | Preset configuration object.
+
+```js
+addFilter( 'presets/stylesheet-loaders', ( loader, environment, config ) => {
+	// Filter the configured stylesheet loaders based on environment or the
+	// specific configuration options provided to the preset factory.
+	return loader;
+} );
+```
+
+## `loaders/postcss/plugins`
+
+Filter the default list of PostCSS plugins used by the PostCSS loader.
+
+Unlike the hooks above, callbacks added to this filter do not receive the preset configuration object.
+
+**Arguments:**
+
+ name | type | description
+----- | ---- | ------
+`pluginsArray` | `Array` | Array of [PostCSS plugin](https://github.com/postcss/postcss#plugins) definitions.
+
+```js
+addFilter( 'loaders/postcss/plugins', ( pluginsArray ) => {
+	// Filter the plugins loaded by PostCSS.
+	return pluginsArray;
+} );
+```
+
+## `loaders/postcss/preset-env`
+
+Filter the [`postcss-preset-env` plugin's](https://github.com/csstools/postcss-plugins/tree/main/plugin-packs/postcss-preset-env#readme) configuration object.
+
+Unlike the hooks above, callbacks added to this filter do not receive the preset configuration object.
+
+```js
+addFilter( 'loaders/postcss/preset-env', ( pluginOptions ) => {
+	// Filter the PostCSS Preset Env plugin options.
+	return pluginOptions;
+} );
+```

--- a/src/loaders.js
+++ b/src/loaders.js
@@ -24,11 +24,27 @@ const loaders = {};
  */
 const createLoaderFactory = loaderKey => {
 	return ( options = {}, config = null ) => {
-		// Generate the requested loader definition. Expose filter seams both
-		// to customize the defaults, and to alter the final rendered output.
+		/**
+		 * Generate the requested loader definition.
+		 *
+		 * Allows customization of the final rendered loader via the loaders/{loaderslug}
+		 * filter, which also receives the configuration passed to a preset factory if
+		 * the loader is invoked in the context of a preset.
+		 *
+		 * @hook loaders/{$loader_slug}
+		 * @param {Object}      loader   Loader definition object, after merging user-provided values with filtered defaults.
+		 * @param {Object|null} [config] Preset configuration object, if loader is called in context of preset.
+		 */
 		return applyFilters(
 			`loaders/${ loaderKey }`,
 			deepMerge(
+				/**
+				 * Filter the loader's default configuration.
+				 *
+				 * @hook loaders/{$loader_slug}/defaults
+				 * @param {Object}      options  Loader default options object.
+				 * @param {Object|null} [config] Preset configuration object, if loader is called in context of preset.
+				 */
 				applyFilters( `loaders/${ loaderKey }/defaults`, loaders[ loaderKey ].defaults, config ),
 				options
 			),
@@ -86,8 +102,20 @@ loaders.postcss.defaults = {
 	options: {
 		postcssOptions: {
 			ident: 'postcss',
+			/**
+			 * Filter the default PostCSS Plugins array.
+			 *
+			 * @hook loaders/postcss/plugins
+			 * @param {Array} plugins Array of PostCSS plugins.
+			 */
 			plugins: applyFilters( 'loaders/postcss/plugins', [
 				postcssFlexbugsFixes,
+				/**
+				 * Filter the default PostCSS Preset Env configuration.
+				 *
+				 * @hook loaders/postcss/preset-env
+				 * @param {Object} presetEnvConfig PostCSS Preset Env plugin configuration.
+				 */
 				postcssPresetEnv( applyFilters( 'loaders/postcss/preset-env', {
 					autoprefixer: {
 						flexbox: 'no-2009',

--- a/src/loaders.js
+++ b/src/loaders.js
@@ -32,8 +32,8 @@ const createLoaderFactory = loaderKey => {
 		 * the loader is invoked in the context of a preset.
 		 *
 		 * @hook loaders/{$loader_slug}
-		 * @param {Object}      loader   Loader definition object, after merging user-provided values with filtered defaults.
-		 * @param {Object|null} [config] Preset configuration object, if loader is called in context of preset.
+		 * @param {Object}      loader   Complete loader definition object, after merging user-provided values with filtered defaults.
+		 * @param {Object|null} [config] Configuration object for the preset being rendered, if loader is called while generating a preset.
 		 */
 		return applyFilters(
 			`loaders/${ loaderKey }`,
@@ -43,7 +43,7 @@ const createLoaderFactory = loaderKey => {
 				 *
 				 * @hook loaders/{$loader_slug}/defaults
 				 * @param {Object}      options  Loader default options object.
-				 * @param {Object|null} [config] Preset configuration object, if loader is called in context of preset.
+				 * @param {Object|null} [config] Configuration object for the preset being rendered, if loader is called while generating a preset.
 				 */
 				applyFilters( `loaders/${ loaderKey }/defaults`, loaders[ loaderKey ].defaults, config ),
 				options

--- a/src/loaders.js
+++ b/src/loaders.js
@@ -15,16 +15,24 @@ const { applyFilters } = require( './helpers/filters' );
  */
 const loaders = {};
 
+/**
+ * Create a loader factory function for a given loader slug.
+ *
+ * @private
+ * @param {string} loaderKey Loader slug
+ * @returns {Function} Factory function to generate and filter a loader with the specified slug.
+ */
 const createLoaderFactory = loaderKey => {
-	return ( options ) => {
+	return ( options = {}, config = null ) => {
 		// Generate the requested loader definition. Expose filter seams both
 		// to customize the defaults, and to alter the final rendered output.
 		return applyFilters(
 			`loaders/${ loaderKey }`,
 			deepMerge(
-				applyFilters( `loaders/${ loaderKey }/defaults`, loaders[ loaderKey ].defaults ),
+				applyFilters( `loaders/${ loaderKey }/defaults`, loaders[ loaderKey ].defaults, config ),
 				options
-			)
+			),
+			config
 		);
 	};
 };

--- a/src/loaders.js
+++ b/src/loaders.js
@@ -54,11 +54,11 @@ const createLoaderFactory = loaderKey => {
 };
 
 // Define all supported loader factories within the loaders object.
-[ 'assets', 'js', 'ts', 'style', 'css', 'postcss', 'sass', 'sourcemaps', 'resource' ].forEach( loaderKey => {
+[ 'asset', 'js', 'ts', 'style', 'css', 'postcss', 'sass', 'sourcemaps', 'resource' ].forEach( loaderKey => {
 	loaders[ loaderKey ] = createLoaderFactory( loaderKey );
 } );
 
-loaders.assets.defaults = {
+loaders.asset.defaults = {
 	test: /\.(png|jpg|jpeg|gif|avif|webp|svg|woff|woff2|eot|ttf)$/,
 	type: 'asset',
 	parser: {

--- a/src/loaders.js
+++ b/src/loaders.js
@@ -54,7 +54,7 @@ const createLoaderFactory = loaderKey => {
 };
 
 // Define all supported loader factories within the loaders object.
-[ 'asset', 'js', 'ts', 'style', 'css', 'postcss', 'sass', 'sourcemaps', 'resource' ].forEach( loaderKey => {
+[ 'asset', 'js', 'ts', 'style', 'css', 'postcss', 'sass', 'sourcemap', 'resource' ].forEach( loaderKey => {
 	loaders[ loaderKey ] = createLoaderFactory( loaderKey );
 } );
 
@@ -136,7 +136,7 @@ loaders.sass.defaults = {
 	},
 };
 
-loaders.sourcemaps.defaults = {
+loaders.sourcemap.defaults = {
 	test: /\.(js|mjs|jsx|ts|tsx|css)$/,
 	exclude: /@babel(?:\/|\\{1,2})runtime/,
 	enforce: 'pre',

--- a/src/loaders.test.js
+++ b/src/loaders.test.js
@@ -30,7 +30,7 @@ describe( 'loaders', () => {
 		} );
 	} );
 
-	describe( '.assets()', () => {
+	describe( '.asset()', () => {
 		it( 'tests for static assets', () => {
 			[
 				'file.png',
@@ -43,14 +43,14 @@ describe( 'loaders', () => {
 				'file.eot',
 				'file.ttf',
 			].forEach( acceptedFileType => {
-				expect( acceptedFileType.match( loaders.assets().test ) ).not.toBeNull();
+				expect( acceptedFileType.match( loaders.asset().test ) ).not.toBeNull();
 			} );
 			[
 				'file.js',
 				'file.css',
 				'file.html',
 			].forEach( unacceptedFileType => {
-				expect( unacceptedFileType.match( loaders.assets().test ) ).toBeNull();
+				expect( unacceptedFileType.match( loaders.asset().test ) ).toBeNull();
 			} );
 		} );
 	} );

--- a/src/presets.js
+++ b/src/presets.js
@@ -133,18 +133,18 @@ const development = ( config = {} ) => {
 			strictExportPresence: true,
 			rules: removeNullLoaders( [
 				// Handle node_modules packages that contain sourcemaps.
-				loaders.sourcemaps(),
+				loaders.sourcemaps( {}, config ),
 				{
 					// "oneOf" will traverse all following loaders until one will
 					// match the requirements. If no loader matches, it will fall
 					// back to the resource loader at the end of the loader list.
 					oneOf: [
 						// Enable processing TypeScript, if installed.
-						...ifInstalled( 'typescript', loaders.ts() ),
+						...ifInstalled( 'typescript', loaders.ts( {}, config ) ),
 						// Process JS with Babel.
-						loaders.js(),
+						loaders.js( {}, config ),
 						// Handle static asset files.
-						loaders.assets(),
+						loaders.assets( {}, config ),
 						// Parse styles using SASS, then PostCSS.
 						// Pass environment name as second parameter to give flexibility when filtering.
 						applyFilters(
@@ -152,29 +152,30 @@ const development = ( config = {} ) => {
 							{
 								test: /\.s?css$/,
 								use: [
-									loaders.style(),
+									loaders.style( {}, config ),
 									loaders.css( {
 										options: {
 											sourceMap: true,
 										},
-									} ),
+									}, config ),
 									loaders.postcss( {
 										options: {
 											sourceMap: true,
 										},
-									} ),
+									}, config ),
 									loaders.sass( {
 										options: {
 											sourceMap: true,
 										},
-									} ),
+									}, config ),
 								],
 							},
-							'development'
+							'development',
+							config
 						),
 						// Resource loader makes sure any non-matching assets still get served.
 						// When you `import` an asset, you get its (virtual) filename.
-						loaders.resource(),
+						loaders.resource( {}, config ),
 					],
 				},
 			] ),
@@ -292,11 +293,11 @@ const production = ( config = {} ) => {
 					// back to the resource loader at the end of the loader list.
 					oneOf: [
 						// Enable processing TypeScript, if installed.
-						...ifInstalled( 'typescript', loaders.ts() ),
+						...ifInstalled( 'typescript', loaders.ts( {}, config ) ),
 						// Process JS with Babel.
-						loaders.js(),
+						loaders.js( {}, config ),
 						// Handle static asset files.
-						loaders.assets(),
+						loaders.assets( {}, config ),
 						// Parse styles using SASS, then PostCSS.
 						// Pass environment name as second parameter to give flexibility when filtering.
 						applyFilters(
@@ -307,16 +308,17 @@ const production = ( config = {} ) => {
 									// Extract CSS to its own file.
 									MiniCssExtractPlugin.loader,
 									// Process SASS into CSS.
-									loaders.css( cssOptions ),
-									loaders.postcss( cssOptions ),
-									loaders.sass( cssOptions ),
+									loaders.css( cssOptions, config ),
+									loaders.postcss( cssOptions, config ),
+									loaders.sass( cssOptions, config ),
 								],
 							},
-							'production'
+							'production',
+							config
 						),
 						// Resource loader makes sure any non-matching assets still get served.
 						// When you `import` an asset, you get its (virtual) filename.
-						loaders.resource(),
+						loaders.resource( {}, config ),
 					],
 				},
 			] ),

--- a/src/presets.js
+++ b/src/presets.js
@@ -145,8 +145,16 @@ const development = ( config = {} ) => {
 						loaders.js( {}, config ),
 						// Handle static asset files.
 						loaders.assets( {}, config ),
-						// Parse styles using SASS, then PostCSS.
-						// Pass environment name as second parameter to give flexibility when filtering.
+						/**
+						 * Filter the full stylesheet loader definition for this preset.
+						 *
+						 * By default parses styles using Sass and then PostCSS.
+						 *
+						 * @hook presets/stylesheet-loaders
+						 * @param {Object} loader      Stylesheet loader rule.
+						 * @param {string} environment "development" or "production".
+						 * @param {Object} config      Preset configuration object.
+						 */
 						applyFilters(
 							'presets/stylesheet-loaders',
 							{
@@ -298,8 +306,16 @@ const production = ( config = {} ) => {
 						loaders.js( {}, config ),
 						// Handle static asset files.
 						loaders.assets( {}, config ),
-						// Parse styles using SASS, then PostCSS.
-						// Pass environment name as second parameter to give flexibility when filtering.
+						/**
+						 * Filter the full stylesheet loader definition for this preset.
+						 *
+						 * By default parses styles using Sass and then PostCSS.
+						 *
+						 * @hook presets/stylesheet-loaders
+						 * @param {Object} loader      Stylesheet loader rule.
+						 * @param {string} environment "development" or "production".
+						 * @param {Object} config      Preset configuration object.
+						 */
 						applyFilters(
 							'presets/stylesheet-loaders',
 							{

--- a/src/presets.js
+++ b/src/presets.js
@@ -65,9 +65,13 @@ const ifInstalled = ( packageName, loader ) => {
 const removeNullLoaders = ( moduleRules ) => moduleRules
 	.map( ( rule ) => {
 		if ( rule && Array.isArray( rule.oneOf ) ) {
+			const loaders = removeNullLoaders( rule.oneOf );
+			if ( ! Array.isArray( loaders ) || ! loaders.length ) {
+				return null;
+			}
 			return {
 				...rule,
-				oneOf: removeNullLoaders( rule.oneOf ),
+				oneOf: loaders,
 			};
 		}
 		if ( rule && Array.isArray( rule.use ) ) {

--- a/src/presets.js
+++ b/src/presets.js
@@ -133,7 +133,7 @@ const development = ( config = {} ) => {
 			strictExportPresence: true,
 			rules: removeNullLoaders( [
 				// Handle node_modules packages that contain sourcemaps.
-				loaders.sourcemaps( {}, config ),
+				loaders.sourcemap( {}, config ),
 				{
 					// "oneOf" will traverse all following loaders until one will
 					// match the requirements. If no loader matches, it will fall

--- a/src/presets.js
+++ b/src/presets.js
@@ -144,7 +144,7 @@ const development = ( config = {} ) => {
 						// Process JS with Babel.
 						loaders.js( {}, config ),
 						// Handle static asset files.
-						loaders.assets( {}, config ),
+						loaders.asset( {}, config ),
 						/**
 						 * Filter the full stylesheet loader definition for this preset.
 						 *
@@ -305,7 +305,7 @@ const production = ( config = {} ) => {
 						// Process JS with Babel.
 						loaders.js( {}, config ),
 						// Handle static asset files.
-						loaders.assets( {}, config ),
+						loaders.asset( {}, config ),
 						/**
 						 * Filter the full stylesheet loader definition for this preset.
 						 *

--- a/src/presets.test.js
+++ b/src/presets.test.js
@@ -282,7 +282,7 @@ describe( 'presets', () => {
 		} );
 
 		it( 'permits filtering the computed output of individual loaders', () => {
-			addFilter( 'loaders/assets', ( loader ) => {
+			addFilter( 'loaders/asset', ( loader ) => {
 				loader.test = /\.(png|jpg|jpeg|gif|svg)$/;
 				return loader;
 			} );
@@ -298,7 +298,7 @@ describe( 'presets', () => {
 				},
 			} );
 			const resourceLoader = getLoaderByName( config.module.rules, 'asset/resource' );
-			const assetsLoader = getLoaderByName( config.module.rules, 'asset' );
+			const assetLoader = getLoaderByName( config.module.rules, 'asset' );
 			const jsLoader = getLoaderByName( config.module.rules, 'babel-loader' );
 			expect( resourceLoader ).toEqual( expect.objectContaining( {
 				exclude: [ /^$/, /\.(js|mjs|jsx|ts|tsx)$/, /\.html?$/, /\.json$/ ],
@@ -307,7 +307,7 @@ describe( 'presets', () => {
 					publicPath: '../../',
 				},
 			} ) );
-			expect( assetsLoader ).toEqual( expect.objectContaining( {
+			expect( assetLoader ).toEqual( expect.objectContaining( {
 				test: /\.(png|jpg|jpeg|gif|svg)$/,
 				type: 'asset',
 				parser: {
@@ -431,7 +431,7 @@ describe( 'presets', () => {
 					{ type: options.type };
 			};
 			addFilter( 'loaders/js', filterToNullInBuild1 );
-			addFilter( 'loaders/assets', filterToNullInBuild1 );
+			addFilter( 'loaders/asset', filterToNullInBuild1 );
 			addFilter( 'loaders/resource', filterToNullInBuild1 );
 			addFilter( 'loaders/sourcemaps', filterToNullInBuild1 );
 
@@ -595,7 +595,7 @@ describe( 'presets', () => {
 		} );
 
 		it( 'permits filtering the computed output of individual loaders', () => {
-			addFilter( 'loaders/assets', ( loader ) => {
+			addFilter( 'loaders/asset', ( loader ) => {
 				loader.test = /\.(png|jpg|jpeg|gif|svg)$/;
 				return loader;
 			} );
@@ -611,7 +611,7 @@ describe( 'presets', () => {
 				},
 			} );
 			const resourceLoader = getLoaderByName( config.module.rules, 'asset/resource' );
-			const assetsLoader = getLoaderByName( config.module.rules, 'asset' );
+			const assetLoader = getLoaderByName( config.module.rules, 'asset' );
 			const jsLoader = getLoaderByName( config.module.rules, 'babel-loader' );
 			expect( resourceLoader ).toEqual( expect.objectContaining( {
 				exclude: [ /^$/, /\.(js|mjs|jsx|ts|tsx)$/, /\.html?$/, /\.json$/ ],
@@ -620,7 +620,7 @@ describe( 'presets', () => {
 					publicPath: '../../',
 				},
 			} ) );
-			expect( assetsLoader ).toEqual( expect.objectContaining( {
+			expect( assetLoader ).toEqual( expect.objectContaining( {
 				test: /\.(png|jpg|jpeg|gif|svg)$/,
 				type: 'asset',
 				parser: {
@@ -739,7 +739,7 @@ describe( 'presets', () => {
 				{ type: options.type };
 		};
 		addFilter( 'loaders/js', filterToNullInBuild1 );
-		addFilter( 'loaders/assets', filterToNullInBuild1 );
+		addFilter( 'loaders/asset', filterToNullInBuild1 );
 		addFilter( 'loaders/resource', filterToNullInBuild1 );
 
 		const config1 = production( { name: 'build1' } );

--- a/src/presets.test.js
+++ b/src/presets.test.js
@@ -433,7 +433,7 @@ describe( 'presets', () => {
 			addFilter( 'loaders/js', filterToNullInBuild1 );
 			addFilter( 'loaders/asset', filterToNullInBuild1 );
 			addFilter( 'loaders/resource', filterToNullInBuild1 );
-			addFilter( 'loaders/sourcemaps', filterToNullInBuild1 );
+			addFilter( 'loaders/sourcemap', filterToNullInBuild1 );
 
 			const config1 = development( { name: 'build1' } );
 			const config2 = development( { name: 'build2' } );


### PR DESCRIPTION
This PR targets the v1 branch (#205), and implements a change requested by @kucrut to permit filter callbacks to be aware of which configuration they are acting upon when called in the context of a preset factory.