### PR TITLE
Include the webpack Image Minimizer Plugin. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,10 @@
   },
   "devDependencies": {
     "eslint": "^7.32.0",
+    "imagemin-gifsicle": "^7.0.0",
+    "imagemin-jpegtran": "^7.0.0",
+    "imagemin-optipng": "^8.0.0",
+    "imagemin-svgo": "^10.0.1",
     "jest": "^26.6.3",
     "sass": "^1.51.0",
     "typescript": "^4.6.3",

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -9,6 +9,7 @@ const RemoveEmptyScriptsPlugin = require( 'webpack-remove-empty-scripts' );
 const SimpleBuildReportPlugin = require( 'simple-build-report-webpack-plugin' );
 const TerserPlugin = require( 'terser-webpack-plugin' );
 const CssMinimizerPlugin = require( 'css-minimizer-webpack-plugin' );
+const ImageMinimizerPlugin = require( 'image-minimizer-webpack-plugin' );
 
 const { applyFilters } = require( './helpers/filters' );
 
@@ -168,6 +169,44 @@ module.exports = {
 	 * @returns {CssMinimizerPlugin} A configured CssMinimizerPlugin instance.
 	 */
 	cssMinimizer: ( options = {} ) => new CssMinimizerPlugin( options ),
+
+	/**
+	 * Image Minimizer Plugin.
+	 *
+	 * @returns {ImageMinimizerPlugin}
+	 */
+	imageMinimizer: () => {
+		// Svgo configuration.
+		// Reference: https://github.com/svg/svgo#configuration
+		// Example: https://github.com/svg/svgo#default-preset
+		const svgoConfig = {
+			plugins: [
+				{
+					name: 'preset-default',
+					params: {
+						overrides: {
+							'removeViewBox': false,
+						},
+					},
+				},
+			],
+		};
+
+		return new ImageMinimizerPlugin( {
+			minimizer: {
+				implementation: ImageMinimizerPlugin.imageminMinify,
+				options: {
+					plugins: [
+						[ 'gifsicle', { interlaced: true } ],
+						[ 'jpegtran', { progressive: true } ],
+						[ 'optipng', { optimizationLevel: 5 } ],
+						[ 'svgo', svgoConfig ],
+					],
+				},
+			},
+		} );
+
+	},
 
 	/**
 	 * Instantiate a SimpleBuildReportPlugin to render build output in a human-

--- a/src/presets.js
+++ b/src/presets.js
@@ -374,6 +374,7 @@ const production = ( config = {} ) => {
 			minimizer: [
 				plugins.terser(),
 				plugins.cssMinimizer(),
+				plugins.imageMinimizer(),
 			],
 			emitOnErrors: false,
 		},


### PR DESCRIPTION
This plugin can optimise any images that are bundled as part of our build process. 

* SVGs are compressed with [SVGO](https://jakearchibald.github.io/svgomg/) (I actually linked to a web interface for this and is a tool I use regularly). Often we'll use icons and logos provided by designers that are poorly optimised. SVG files can contain lots of stuff generated by the tool used to create the image. SVGO strips it out and can often reduce file sizes by 50% or more.
* JPG files are compressed using [jpegtran](https://jpegclub.org/jpegtran/). I tested this on a 4.6MB file and it reduced it by about 7%. So not a lot! But better than nothing. 
* PNG files. I tested on a couple of images. One very small one exported from Figma, was reduced by about 40% (from 2kb to 1.3kb). But repeating this with another image I didn't see any improvement at all. I guess it depends how well optimised the source image is.

All in all, seems like an easy enhancement to add with little downside.

Any thoughts on including this?