### PR TITLE
Update to Jekyll 4, inherit from theme

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -32,6 +32,10 @@ jobs:
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v2
+      - name: Bundle install
+        run: |
+          bundle install --path=vendor/bundle --jobs 4 --retry 3
+          bundle clean
       - name: Build with Jekyll
         run: |
           cd docs

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,5 +1,5 @@
-source 'https://rubygems.org'
-gem 'github-pages', group: :jekyll_plugins
+source "https://rubygems.org"
 
+gem "jekyll", "~> 4.3.2"
 gem "webrick", "~> 1.8"
-gem "just-the-hm-docs", ">= 1.0.1.rc1"
+gem "just-the-hm-docs", github: "humanmade/just-the-hm-docs"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -19,38 +19,17 @@ author: Human Made
 baseurl: "/webpack-helpers" # the subpath of your site, e.g. /blog
 url: "https://humanmade.github.io" # the base hostname & protocol for your site, e.g. http://example.com
 
-# Set a path/url to a logo that will be displayed instead of the title
-logo: "/assets/icons/hm-logo.svg"
-
-# Set a path/url to a favicon that will be displayed by the browser
-favicon_ico: "/assets/favicon/favicon.ico"
-
 # Theme settings
 theme: just-the-hm-docs
-color_scheme: hm
-permalink: pretty
 
 # Aux links for the upper right navigation
 aux_links:
-  Human Made:
-    - "//humanmade.com"
   Webpack-Helpers on GitHub:
     - "//github.com/humanmade/webpack-helpers"
 
-callouts_level: quiet # or loud
-callouts_opacity: 0.3
-callouts:
-  highlight:
-    color: yellow
-  important:
-    title: Important
-    color: hm-purple-callout
-  new:
-    title: New
-    color: hm-mint-callout
-  note:
-    title: Note
-    color: hm-blue-callout
-  warning:
-    title: Warning
-    color: hm-red-callout
+defaults:
+  -
+    scope:
+      path: "" # an empty string here means all files in the project
+    values:
+      layout: "default"


### PR DESCRIPTION
We updated Just the HM Docs to Jekyll 4 in https://github.com/humanmade/just-the-hm-docs/pull/11 so that we could inherit site variables from the theme config. 

This PR makes those updates to the gemfile and config, and adds a necessary `bundle install` step to the deploy action.

It also adds Front Matter layout defaults to the config file so that all markdown files don't need to specify a layout. This fixes a problem we found with Webpack Helpers not loading the theme properly if we removed the github-pages gem. 