### PR TITLE
Update getting-started.md

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -16,9 +16,18 @@ npm install --save-dev @humanmade/webpack-helpers
 
 While this package depends in turn on a number of loaders and plugins, it deliberately does _not_ include `webpack` itself. To install this library along with all its relevant peer dependencies, therefore, you may run the following command:
 
+** *Check notice before proceeding:**
 ```bash
 npm install --save-dev @humanmade/webpack-helpers webpack@4 webpack-cli@3 webpack-dev-server sass
 ```
+
+***❗ *Notice***
+This verson is outdated and might leave you with outdated versions of this library and associated Webpack tooling.
+There's a [pending release](https://github.com/humanmade/webpack-helpers/pull/205) that will fix this problem. But for now you should install humanmade/webpack-helpers@beta, webpack @5, webpack-cli@4, and webpack-dev-server@4. To do so runu the following command:
+```bash
+npm install --save-dev @humanmade/webpack-helpers@beta webpack@5 webpack-cli@4 webpack-dev-server@4
+```
+
 
 Note that we specify Webpack version 4. Support for Webpack 5 is anticipated in the v1.0 release of these helpers, but at present using Webpack 4 provides the most predictable and stable experience across our projects.
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -21,15 +21,14 @@ While this package depends in turn on a number of loaders and plugins, it delibe
 npm install --save-dev @humanmade/webpack-helpers webpack@4 webpack-cli@3 webpack-dev-server sass
 ```
 
+Note that we specify Webpack version 4. Support for Webpack 5 is anticipated in the v1.0 release of these helpers, but at present using Webpack 4 provides the most predictable and stable experience across our projects.
+
 ***❗ *Notice***
 This verson is outdated and might leave you with outdated versions of this library and associated Webpack tooling.
-There's a [pending release](https://github.com/humanmade/webpack-helpers/pull/205) that will fix this problem. But for now you should install humanmade/webpack-helpers@beta, webpack @5, webpack-cli@4, and webpack-dev-server@4. To do so runu the following command:
+There's a [pending release](https://github.com/humanmade/webpack-helpers/pull/205) that will fix this problem. But for now you should install humanmade/webpack-helpers@beta, webpack @5, webpack-cli@4, and webpack-dev-server@4. To do so run the following command:
 ```bash
 npm install --save-dev @humanmade/webpack-helpers@beta webpack@5 webpack-cli@4 webpack-dev-server@4
 ```
-
-
-Note that we specify Webpack version 4. Support for Webpack 5 is anticipated in the v1.0 release of these helpers, but at present using Webpack 4 provides the most predictable and stable experience across our projects.
 
 ## Configuring Webpack
 


### PR DESCRIPTION
Until [#205](https://github.com/humanmade/webpack-helpers/pull/205) lands, the steps for getting started on https://humanmade.github.io/webpack-helpers/guides/getting-started.html leave you with outdated versions of this library and associated Webpack tooling, which don't work in recent versions of Node. We should add a section within the getting started calling out to use.

Check issue #215