### PR TITLE
 Replace Babel 6 JSX transform with @babel/plugin-transform-react-jsx

### DIFF
--- a/babel-preset.js
+++ b/babel-preset.js
@@ -2,10 +2,10 @@ module.exports = ( api ) => {
 	api.cache.forever();
 
 	return {
-		presets: [ '@wordpress/default' ],
+		presets: [ '@wordpress/babel-preset-default' ],
 		plugins: [
 			'@babel/plugin-proposal-class-properties',
-			[ 'transform-react-jsx', {
+			[ '@babel/plugin-transform-react-jsx', {
 				pragma: 'wp.element.createElement',
 			} ],
 		],

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@wordpress/babel-preset-default": "^8.30.0",
     "babel-loader": "^10.0.0",
-    "babel-plugin-transform-react-jsx": "^6.24.1",
+    "@babel/plugin-transform-react-jsx": "^7.0.0",
     "bell-on-bundler-error-plugin": "^3.0.0",
     "block-editor-hmr": "^0.7.0",
     "chalk": "^5.6.0",


### PR DESCRIPTION
The babel-plugin-transform-react-jsx helper package doesn't support some of the syntax which babel 7 can process. Since we're using babel 7 packages like @babel/traverse, it makes sense to upgrade to the Babel 7 equivalent. 

This adds support for syntax like optional chaining, which is the use case I discovered updating this in another project (right after tagging v1.0.0 :facepalm:).